### PR TITLE
Markdownify descriptions for orgs and datasets

### DIFF
--- a/_datasets/2009-2012-police-advisory-commission-complaints.md
+++ b/_datasets/2009-2012-police-advisory-commission-complaints.md
@@ -11,9 +11,7 @@ maintainer: ''
 maintainer_email: ''
 notes: "The datasets below show information about Complaints filed with the Police\
   \ Advisory Commission against Philadelphia Police officers. The information comes\
-  \ directly from Police Advisory Commission Complaint Database. \r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ directly from Police Advisory Commission Complaint Database."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Never'

--- a/_datasets/311-service-and-information-requests.md
+++ b/_datasets/311-service-and-information-requests.md
@@ -14,9 +14,7 @@ notes: "This represents all service and information requests since December 8th,
   \ the data.**\r\n\r\nIf you are comfortable with APIs, you can also use the API\
   \ links to access this data. You can learn more about how to use the API at [Carto\u2019\
   s SQL API site](https://carto.com/developers/sql-api/)  and in the [Carto guide\
-  \ in the section on making calls to the API](https://carto.com/developers/sql-api/guides/making-calls/).**\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ in the section on making calls to the API](https://carto.com/developers/sql-api/guides/making-calls/).**"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/active-residential-parking-permits-by-district.md
+++ b/_datasets/active-residential-parking-permits-by-district.md
@@ -6,8 +6,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly
-  Discussion Group](http://www.phila.gov/data/discuss/)
+notes: 
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/aerial-photography.md
+++ b/_datasets/aerial-photography.md
@@ -11,9 +11,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: Office of Innovation & Technology
 maintainer_email: brian.ivey@phila.gov
-notes: "Data includes aerial photography of the City of Philadelphia.\r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Data includes aerial photography of the City of Philadelphia."
 organization: City of Philadelphia
 resources:
 - description: 'NOTE: To download shapefiles from PASDA, you need to copy the Download

--- a/_datasets/air-monitoring-stations.md
+++ b/_datasets/air-monitoring-stations.md
@@ -8,8 +8,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Street location and types of pollutants sampled at each PDPH air monitoring\
-  \ station.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ station."
 organization: City of Philadelphia
 resources:
 - description: "Update frequency: Yearly\r\n"

--- a/_datasets/air-quality-index-days.md
+++ b/_datasets/air-quality-index-days.md
@@ -7,9 +7,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: mos@phila.gov
 maintainer_email: ''
-notes: "Number of bad AQI (air quality index) days, dating back to 1990.\r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Number of bad AQI (air quality index) days, dating back to 1990."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ams-latest-air-quality-sensor-readings.md
+++ b/_datasets/ams-latest-air-quality-sensor-readings.md
@@ -12,9 +12,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "The latest air quality sensor readings managed by the Air Management Systems\
-  \ (AMS) division of the Philadelphia Department of Public Health (PDPH)\r\n\r\n\
-  Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ (AMS) division of the Philadelphia Department of Public Health (PDPH)"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/archived-2007-2015-litter-index.md
+++ b/_datasets/archived-2007-2015-litter-index.md
@@ -13,8 +13,7 @@ notes: "The datasets below have been archived and will not receive further updat
   \ Litter Index data, please be advised that the survey design between the 2007-\
   \ 2015 data is vastly different from the 2017 data, so it would not make sense to\
   \ compare the two. \r\n\r\nThe Litter Index is used to compare the relative cleanliness\
-  \ of different areas of the city of Philadelphia.  \r\n\r\nTrouble downloading or\
-  \ have questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ of different areas of the city of Philadelphia.  "
 organization: City of Philadelphia
 resources:
 - description: 'This dataset is archived and will not receive further updates. '

--- a/_datasets/archived-greenworks-metrics.md
+++ b/_datasets/archived-greenworks-metrics.md
@@ -15,8 +15,7 @@ notes: "The following datasets are no longer maintained and will not receive fur
   \ pollution.\r\n*Benefit from parks, trees, stormwater management, and healthy waterways.\r\
   \n*Have access to safe, affordable, and low-carbon transportation.\r\n*Waste less\
   \ and keep our neighborhoods clean.\r\n*Benefit from sustainability education, employment,\
-  \ and business opportunities.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ and business opportunities."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/archived-philadelphia-food-access.md
+++ b/_datasets/archived-philadelphia-food-access.md
@@ -14,8 +14,7 @@ notes: "The datasets below have been archived and will not receive further updat
   \ analysis using this data, please be advised that the previous methodology is vastly\
   \ different from the more recent data, so it would not make sense to compare the\
   \ two.\r\n\r\nThis dataset is derived from the Walkable Access to Healthy Foods\
-  \ in Philadelphia, 2012-2014 report analyses.\r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ in Philadelphia, 2012-2014 report analyses."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Archived'

--- a/_datasets/archived-planning-analysis-sections.md
+++ b/_datasets/archived-planning-analysis-sections.md
@@ -14,8 +14,7 @@ maintainer_email: brian.ivey@phila.gov
 notes: "Please note that this dataset is no longer in use by the Philadelphia City\
   \ Planning Commission and has been replaced with the [Planning Districts dataset](https://www.opendataphilly.org/dataset/planning-districts).\r\
   \n\r\nThe Planning Analysis Sections were the boundaries for the city's twelve planning\
-  \ analysis sections with attribute labels. \r\n \r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ analysis sections with attribute labels."
 organization: City of Philadelphia
 resources:
 - description: 'Multiple formats available for download, including SHP. '

--- a/_datasets/archived-valet-parking-locations.md
+++ b/_datasets/archived-valet-parking-locations.md
@@ -6,9 +6,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "Data is from 2015 and does not currently receive any updates. \r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Data is from 2015 and does not currently receive any updates. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/arterial-streets.md
+++ b/_datasets/arterial-streets.md
@@ -6,8 +6,7 @@ maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 notes: "The Arterial layer was developed to aid various city agencies with planning,\
   \ organizing, and maintaining the streets of the City of Philadelphia.  These agencies\
-  \ include PWD, PCPC, Police, BRT, Health, etc. \r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ include PWD, PCPC, Police, BRT, Health, etc. "
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/big-belly-trash-bin-usage.md
+++ b/_datasets/big-belly-trash-bin-usage.md
@@ -5,8 +5,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly
-  Discussion Group](http://www.phila.gov/data/discuss/)
+notes: 
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/big-belly-waste-baskets-trash-bins.md
+++ b/_datasets/big-belly-waste-baskets-trash-bins.md
@@ -7,9 +7,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
-notes: "Big Belly brand waste baskets maintained/collected by the City of Philadelphia.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Big Belly brand waste baskets maintained/collected by the City of Philadelphia."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/bike-network-supporting-datasets.md
+++ b/_datasets/bike-network-supporting-datasets.md
@@ -18,8 +18,7 @@ notes: "This dataset combines data from various City of Philadelphia departments
   \ paths. Each dataset has its own parameters, dates, and sources, and individuals\
   \ are encouraged to view the metadata associated with this data. \r\n<br></br>\r\
   \nThis dataset is experimental and remains a work in progress. Please use with caution.\
-  \ \r\n\r\nTrouble downloading or have questions about this City dataset? Visit the\
-  \ [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/bike-network.md
+++ b/_datasets/bike-network.md
@@ -14,9 +14,7 @@ license: Other (City of Philadelphia)
 maintainer: Streets Department
 maintainer_email: ''
 notes: "Line data includes the network of both streets with bike lanes and streets\
-  \ considered bicycle-friendly. Also known as the bicycle network. \r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ considered bicycle-friendly. Also known as the bicycle network. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/bridge-locations.md
+++ b/_datasets/bridge-locations.md
@@ -7,8 +7,7 @@ maintainer_email: michael.matela@phila.gov
 notes: "This layer was developed to aid the Bridge Division in maintaining and referencing\
   \ the bridges of the City of Philadelphia.  Examples include: routing trucks with\
   \ height and weight restrictions through out the city, maintenance, and obtaining\
-  \ bridge number.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ bridge number."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/building-demolitions.md
+++ b/_datasets/building-demolitions.md
@@ -11,8 +11,7 @@ maintainer_email: LIGISTEAM@phila.gov
 notes: "Inventory of building demolitions occurring within the City of Philadelphia.\
   \ This includes both demolitions performed by private owners/contractors and by\
   \ the Department of Licenses and Inspections due to dangerous building conditions.\
-  \ \r\n\r\nUpdated daily. \r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ \r\n\r\nUpdated daily. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/building-footprints.md
+++ b/_datasets/building-footprints.md
@@ -14,8 +14,7 @@ maintainer: ''
 maintainer_email: ''
 notes: "Planimetric Coverage containing the delineation of buildings or related structure\
   \ outlines that represent the footprints of buildings within the City of Philadelphia.\
-  \ \r\n\r\nTrouble downloading or have questions about this City dataset? Visit the\
-  \ [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  "
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Weekly'

--- a/_datasets/bullet-voting-2015.md
+++ b/_datasets/bullet-voting-2015.md
@@ -6,9 +6,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Each voter is allowed to select up to five candidates for City Council At-Large.\
-  \ When a voter chooses only one candidate, it is known as \u201Cbullet voting.\u201D\
-  \r\n\r\nTrouble downloading or have questions about this City dataset? Visit the\
-  \ [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ When a voter chooses only one candidate, it is known as \u201Cbullet voting.\u201D"
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: N/A'

--- a/_datasets/business-security-camera-program-grants.md
+++ b/_datasets/business-security-camera-program-grants.md
@@ -9,8 +9,7 @@ maintainer: ''
 maintainer_email: ''
 notes: "Information regarding the number of recipients of grant monies for the Business\
   \ Security Camera Program. Used for tracking completed projects, by zip code and\
-  \ census tract and dollar value of reimbursement.\r\n\r\nTrouble downloading or\
-  \ have questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ census tract and dollar value of reimbursement."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/business-technical-support-resources.md
+++ b/_datasets/business-technical-support-resources.md
@@ -5,9 +5,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "Services and support available to businesses in Philadelphia. \r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Services and support available to businesses in Philadelphia. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/campaign-finance-reports.md
+++ b/_datasets/campaign-finance-reports.md
@@ -17,9 +17,7 @@ notes: "Campaign finance reports from 2019 to the present: The tables below show
   \ to learn how to navigate the dashboard, or read the [technical document](https://docs.google.com/document/d/1VzeY_HJOATS17pE4639OZq0fhrF7Jppps-Mc3dZhDqY/edit?usp=sharing)\
   \ to understand how we compiled the data and dashboard. \r\n\r\nIf you want to use\
   \ the raw, unfiltered data, please visit the [searchable database](https://apps.phila.gov/search/all).\
-  \ Filers can submit reports on via the [campaign finance filing system](https://apps.phila.gov/auth).\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Filers can submit reports on via the [campaign finance filing system](https://apps.phila.gov/auth)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/candidates.md
+++ b/_datasets/candidates.md
@@ -9,8 +9,7 @@ maintainer_email: seth.bluestein@phila.gov
 notes: "***THIS DATASET IS UNDER CONSTRUCTION AND WILL BE RE-RELEASED SHORTLY***\r\
   \n\r\nThe individuals who are candidates for elected office.  Internally, this information\
   \ is used to create the ballot. Externally, candidates and campaigns will want to\
-  \ know who their opponents are. \r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ know who their opponents are. "
 organization: City of Philadelphia
 resources:
 - description: THIS DATASET IS UNDER CONSTRUCTION AND WILL BE RE-RELEASED SHORTLY

--- a/_datasets/census-block-groups.md
+++ b/_datasets/census-block-groups.md
@@ -14,9 +14,7 @@ maintainer_email: darshna.patel@phila.gov
 notes: "For matching and analyzing demographic data collected and compiled by the\
   \ U.S. Census Bureau & American Community Survey(ACS) to the geography of Census\
   \ Block Group boundaries within the City of Philadelphia. These boundaries can change\
-  \ every ten years when the decennial census is conducted. \r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ every ten years when the decennial census is conducted."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/census-blocks.md
+++ b/_datasets/census-blocks.md
@@ -19,8 +19,7 @@ notes: "The basic unit of aggregation published by the US Census Bureau.  Popula
   \ statistics published for redistricting are distributed at the block level.  In\
   \ an urban area, this corresponds to approximately one city block.  This block map\
   \ has been altered to improve accuracy and align with the City of Philadelphia's\
-  \ street centerline.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ street centerline."
 organization: City of Philadelphia
 resources:
 - description: For matching and analyzing demographic data collected and compiled

--- a/_datasets/census-tracts.md
+++ b/_datasets/census-tracts.md
@@ -15,8 +15,7 @@ notes: "For matching and analyzing demographic data collected and compiled by th
   \ U.S. Census Bureau & American Community Survey(ACS) to the geography of Census\
   \ Block Group boundaries within the City of Philadelphia. These boundaries can change\
   \ every ten years when the decennial census is conducted. Adjusted to City's Standard\
-  \ Boundary Format.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Boundary Format."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: When the Census changes boundaries for each data

--- a/_datasets/center-city-district-boundary-business-improvement-district.md
+++ b/_datasets/center-city-district-boundary-business-improvement-district.md
@@ -9,8 +9,7 @@ maintainer_email: publicsafetygis@phila.gov
 notes: "Center City District encompasses 120 blocks and more than 4500 individual\
   \ properties. The mission is to keep Center City clean, safe, and fun.  CCD also\
   \ makes phyiscal improvements to center city by installing and maintain lighting,\
-  \ signs, banners trees and landscape.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ signs, banners trees and landscape."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/certified-for-rental-suitability.md
+++ b/_datasets/certified-for-rental-suitability.md
@@ -7,9 +7,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: ligisteam@phila.gov
 maintainer_email: ligisteam@phila.gov
-notes: "Properties that have applied and been approved as suitable for renting. \r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Properties that have applied and been approved as suitable for renting. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/choice-neighborhoods.md
+++ b/_datasets/choice-neighborhoods.md
@@ -8,9 +8,7 @@ maintainer_email: mark.dodds@phila.gov
 notes: "The Choice Neighborhoods program is administered by the U.S. Department of\
   \ Housing and Urban Development (HUD).  It supports locally driven strategies to\
   \ address struggling neighborhoods with distressed public or HUD-assisted housing\
-  \ through a comprehensive approach to neighborhood transformation. \r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ through a comprehensive approach to neighborhood transformation. "
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/city-council-districts.md
+++ b/_datasets/city-council-districts.md
@@ -6,8 +6,7 @@ license: Other (City of Philadelphia)
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 notes: "City Council Districts (1990),\r\nCity Council Districts (2000), and\r\nCity\
-  \ Council Districts (2016)\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Council Districts (2016)"
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed '

--- a/_datasets/city-employee-earnings.md
+++ b/_datasets/city-employee-earnings.md
@@ -16,8 +16,7 @@ notes: "__This data does not necessarily represent current salaries of employees
   \ of the BASE_SALARY field does not reflect the total budgeted amount. Also, when\
   \ the BASE_SALARY column is blank, it represents part-time, temporary, or seasonal\
   \ employees paid by the hour. Please see [metadata](https://metadata.phila.gov/#home/datasetdetails/5543865520583086178c4ebd/representationdetails/604284dc49a209001d746460/?view_287_per_page=25&view_287_page=1)\
-  \ for detailed explanations of each field.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ for detailed explanations of each field."
 organization: City of Philadelphia
 resources:
 - description: A visualization of the latest  available quarter's data on City of

--- a/_datasets/city-facilities-master-facilities-database.md
+++ b/_datasets/city-facilities-master-facilities-database.md
@@ -9,9 +9,7 @@ maintainer: Rich Quodomine
 maintainer_email: richard.quodomine@phila.gov
 notes: "An inventory of buildings and other fixed assets owned, leased, or operated\
   \ by the City of Philadelphia including buildings, structures, and properties (not\
-  \ including surplus properties). Also known as the Master Facilities Database. \r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ including surplus properties). Also known as the Master Facilities Database. "
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/city-landmarks.md
+++ b/_datasets/city-landmarks.md
@@ -7,8 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: maps@phila.gov
 maintainer_email: maps@phila.gov
 notes: "An inventory of cultural landmarks found within the borders of the City of\
-  \ Philadelphia.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Philadelphia."
 organization: City of Philadelphia
 resources:
 - description: "Give feedback on and submit missing landmarks of cultural, historical\

--- a/_datasets/city-limits.md
+++ b/_datasets/city-limits.md
@@ -12,8 +12,7 @@ maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 notes: "To provide a base for very generalized maps or used as an outline in conjunction\
   \ with other data layers.  Establishes City Limits for City's Standard Boundary\
-  \ Format. This layer was updated on July 22, 2012.\r\n\r\nTrouble downloading or\
-  \ have questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Format. This layer was updated on July 22, 2012."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/city-operating-budget.md
+++ b/_datasets/city-operating-budget.md
@@ -10,9 +10,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Proposed, adopted, and estimated operating budgets for City of Philadelphia\
-  \ government. The City's Fiscal Year begins July 1st and ends June 30th.\r\n\r\n\
-  Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ government. The City's Fiscal Year begins July 1st and ends June 30th."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/city-owned-bridges.md
+++ b/_datasets/city-owned-bridges.md
@@ -6,9 +6,7 @@ license: Other (City of Philadelphia)
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 notes: "This layer identifies the point locations of the city owned bridges that are\
-  \ maintained by the Bridge Division of the City of Philadelphia Streets Department.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ maintained by the Bridge Division of the City of Philadelphia Streets Department."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/city-owned-properties.md
+++ b/_datasets/city-owned-properties.md
@@ -7,8 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: PHDC
 maintainer_email: ''
 notes: "Web application displaying properties owned by the City, PHDC/RDA or other\
-  \ public entities.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ public entities."
 organization: City of Philadelphia
 resources:
 - description: A map of all properties in public ownership that are available. It

--- a/_datasets/city-plan-boundary.md
+++ b/_datasets/city-plan-boundary.md
@@ -8,8 +8,7 @@ maintainer_email: dominick.cassise@phila.gov
 notes: "This layer was developed to aid the Surveys Division in planning, modifying\
   \ and referencing the streets within a city plan of the City of Philadelphia.  Examples\
   \ include:  building new streets, modifying existing streets, or observing current\
-  \ streets.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ streets."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/city-registered-local-businesses.md
+++ b/_datasets/city-registered-local-businesses.md
@@ -9,9 +9,7 @@ maintainer_email: ''
 notes: "The City of Philadelphia gives preference to certified local businesses through\
   \ its Local Business Entity program. This dataset provides a list of currently certified\
   \ local businesses registered with the City of Philadelphia.\r\n\r\nFor more information,\
-  \ visit:\r\nhttps://www.phila.gov/departments/procurement-department/local-preference/\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ visit:\r\nhttps://www.phila.gov/departments/procurement-department/local-preference/"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/civil-service-positions-details.md
+++ b/_datasets/civil-service-positions-details.md
@@ -8,8 +8,7 @@ maintainer: Jerome Lomax
 maintainer_email: jerome.lomax@phila.gov
 notes: "These datasets show job classification and pay ranges details about Civil\
   \ Service positions approved by the Civil Service commission and Administrative\
-  \ board.\r\n\r\nTrouble downloading or have questions about this City dataset? Visit\
-  \ the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ board."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/combined-sewer-service-area.md
+++ b/_datasets/combined-sewer-service-area.md
@@ -14,9 +14,7 @@ notes: "This layer is dissolved and queried from PWD's internal sewer shed featu
   \ storm and/or combined sewer flows. These catchments are used in the hydraulic\
   \ models. Data DevelopmentBase Modelsheds are maintained regularly and delineate\
   \ waste water and stormwater and combined sewer catchments in Philadelphia. Storm\
-  \ water and waste water pipe flow are analyzed to delineate the shed boundaries.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ water and waste water pipe flow are analyzed to delineate the shed boundaries."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/commercial-corridors-of-philadelphia.md
+++ b/_datasets/commercial-corridors-of-philadelphia.md
@@ -9,8 +9,7 @@ maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 notes: "These are commercial corridors, centers, districts, and projects that provide\
   \ consumer-oriented goods and services, including retail, food and beverage, and\
-  \ personal, professional, and business services. \r\n\r\nTrouble downloading or\
-  \ have questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ personal, professional, and business services. "
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/commodities-contracts.md
+++ b/_datasets/commodities-contracts.md
@@ -12,9 +12,7 @@ notes: "Commodities contracts are bid and awarded by the Procurement Department,
   \ during the given quarter.\r\n\r\nWhen you click on a file below and it opens in\
   \ a new tab, simple right click on the page, and choose 'save as.' When the save\
   \ as dialog box appears, make sure the 'save as type' is Microsoft Excel Comma Separated\
-  \ Values File. You should then be able to open in excel.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ Values File. You should then be able to open in excel."
 organization: City of Philadelphia
 resources:
 - description: 'An app to view procurement contracts.  '

--- a/_datasets/community-compost-network-site.md
+++ b/_datasets/community-compost-network-site.md
@@ -6,9 +6,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
-notes: "Community compost network sites located throughout the City of Philadelphia.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Community compost network sites located throughout the City of Philadelphia."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
+++ b/_datasets/community-health-assessment-philadelphia-department-of-public-health.md
@@ -16,9 +16,7 @@ notes: "The Community Health Assessment (CHA) is a systematic assessment of popu
   \ of Public Health publishes an annual report of the analyses, linked to under the\
   \ 'Related' tab. Additionally, they have released an online, interactive version\
   \ of the CHA, known as the Community Health Explorer, to make the data more accessible\
-  \ to a broader audience: http://cityofphiladelphia.github.io/community-health-explorer/\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)\r\n\r\n\r\n"
+  \ to a broader audience: http://cityofphiladelphia.github.io/community-health-explorer/\r\n\r\n\r\n"
 organization: City of Philadelphia
 resources:
 - description: 'Interactive web application to see charts and maps of the community

--- a/_datasets/complete-streets.md
+++ b/_datasets/complete-streets.md
@@ -24,9 +24,7 @@ notes: "The Complete Streets Layer combines the Street Types developed by the Ci
   \ Handbook of the Mayor\u2019s Office of Transportation and Utilities. It allows\
   \ developers, planners, engineers and community groups to easily identify their\
   \ street type and associated pedestrian, bicycle and other travel priorities to\
-  \ be included during the planning of new streets or large developments.\r\n\r\n\
-  Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ be included during the planning of new streets or large developments."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/condom-distribution-sites.md
+++ b/_datasets/condom-distribution-sites.md
@@ -8,8 +8,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Street location and hours of stores and organizations that distribute PDPH\
-  \ Freedom Condom-branded condoms.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Freedom Condom-branded condoms."
 organization: City of Philadelphia
 resources:
 - description: "Update frequency: Biannually\r\n\r\n"

--- a/_datasets/correctional-facilities-locations.md
+++ b/_datasets/correctional-facilities-locations.md
@@ -7,8 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 notes: "These layers illustrate 10 correctional facilities in the City, administered\
-  \ by the Philadelphia Prisons System.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ by the Philadelphia Prisons System."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/courts.md
+++ b/_datasets/courts.md
@@ -8,9 +8,7 @@ maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 notes: "Point data of all First Judicial District of PA courts. Aside from the courts\
   \ and locations, a main telephone number was added for each court. All information\
-  \ was provided by http://www.courts.phila.gov/locations.asp\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ was provided by http://www.courts.phila.gov/locations.asp"
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/covid-19-test-sites.md
+++ b/_datasets/covid-19-test-sites.md
@@ -14,9 +14,7 @@ notes: "A dataset of free COVID-19 testing sites. \r\n\r\n__If looking for a tes
   \ sites may:\r\n* Limit testing to people who meet certain criteria.\r\n* Require\
   \ an appointment.\r\n* Require a referral from your doctor.\r\n* Ask you to stay\
   \ in your car (for drive-thru sites).\r\n\r\nCheck a location\u2019s specific details\
-  \ on the map. Then, call or visit the provider's website before going for a test.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ on the map. Then, call or visit the provider's website before going for a test."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/covid-19-vaccinations.md
+++ b/_datasets/covid-19-vaccinations.md
@@ -10,9 +10,7 @@ notes: "***As of May 2022, these datasets moved from daily updates to weekly upd
   \ every Monday.***\r\n\r\nShows distribution counts of first and second dose, as\
   \ well as total dose information for all vaccinations performed by the health department.\
   \ Also provides vaccinations by census tract, ZIP code, date, age, race, and sex.\
-  \ Vaccinations include residents and non-residents of Philadelphia. Updates daily.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Vaccinations include residents and non-residents of Philadelphia. Updates daily."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/covid-deaths.md
+++ b/_datasets/covid-deaths.md
@@ -16,9 +16,7 @@ notes: "***As of May 2022, these datasets moved from daily updates to weekly upd
   \n\r\nDeidentified, aggregate datasets showing COVID deaths by date, zip, race,\
   \ or age. You can [find COVID cases datasets here](https://www.opendataphilly.org/dataset/covid-cases).\
   \ To protect the confidentiality of residents, PDPH suppresses the exact data for\
-  \ any categories that have less than 6 counts (i.e. of cases or fatalities).\r\n\
-  \r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ any categories that have less than 6 counts (i.e. of cases or fatalities)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/covid-hospitalizations.md
+++ b/_datasets/covid-hospitalizations.md
@@ -8,8 +8,7 @@ maintainer: PublicHealthInfo@phila.gov
 maintainer_email: PublicHealthInfo@phila.gov
 notes: "***As of May 2022, these datasets moved from daily updates to weekly updates\
   \ every Monday.***\r\n\r\nA break down by census categories of the hospitalizations\
-  \ to date within the city limits.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ to date within the city limits."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/covid-tests-and-cases.md
+++ b/_datasets/covid-tests-and-cases.md
@@ -17,9 +17,7 @@ notes: "***As of May 2022, these datasets moved from daily updates to weekly upd
   \ missing from the data.**\r\n\r\nDeidentified, aggregate datasets showing COVID\
   \ tests by date, zip, and outcome and cases by race, age or sex.  To protect the\
   \ confidentiality of residents, PDPH suppresses the exact data for any categories\
-  \ that have less than 6 counts (i.e. of tests or fatalities).\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ that have less than 6 counts (i.e. of tests or fatalities)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/crime-incidents.md
+++ b/_datasets/crime-incidents.md
@@ -13,8 +13,7 @@ notes: "Crime incidents from the Philadelphia Police Department. Part I crimes i
   \ download all datasets for all years.** \r\n\r\n**If you are comfortable with APIs,\
   \ you can also use the API links to access this data. You can learn more about how\
   \ to use the API at Carto\u2019s SQL API site and in the Carto guide in the section\
-  \ on making calls to the API.**\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ on making calls to the API.**"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/curbs.md
+++ b/_datasets/curbs.md
@@ -11,8 +11,7 @@ maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 notes: "This data includes curb edges with cartways and curb edges without cartways\
   \ to represent travelways within the City of Philadelphia and it aids in placement\
-  \ of street centerline.\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ of street centerline."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Quarterly '

--- a/_datasets/dams.md
+++ b/_datasets/dams.md
@@ -5,8 +5,7 @@ license: Other (City of Philadelphia)
 maintainer: Larry Szarek
 maintainer_email: larry.szarek@phila.gov
 notes: "This layer shows point representation of all the dams in Philadelphia with\
-  \ latitude and longitude coordinates.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ latitude and longitude coordinates."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/department-of-records-easement.md
+++ b/_datasets/department-of-records-easement.md
@@ -9,8 +9,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Polygon description of use rights for ingress/egress, driveways, alleyways,\
-  \ utilities, drainage and subsurface areas. \r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ utilities, drainage and subsurface areas. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/department-of-records-property-parcels.md
+++ b/_datasets/department-of-records-property-parcels.md
@@ -10,8 +10,7 @@ license: Other (City of Philadelphia)
 maintainer: Tracy Dandridge
 maintainer_email: tracy.dandridge@phila.gov
 notes: "Department of Records (DOR) Boundaries of real estate property parcels derived\
-  \ from legal recorded deed documents. \r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ from legal recorded deed documents. "
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Weekly'

--- a/_datasets/digital-elevation-model-dem.md
+++ b/_datasets/digital-elevation-model-dem.md
@@ -5,9 +5,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "A digital elevation model (DEM) is a digital model or 3D representation of\
-  \ a terrain's surface, created from terrain elevation data.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ a terrain's surface, created from terrain elevation data."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/economic-opportunity-plans.md
+++ b/_datasets/economic-opportunity-plans.md
@@ -5,8 +5,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: Nicholas Jann
 maintainer_email: nicholas.jann@phila.gov
-notes: "Economic Opportunity Plans (EOP)\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Economic Opportunity Plans (EOP)"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/elected-committee-people.md
+++ b/_datasets/elected-committee-people.md
@@ -7,8 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: Seth Bluestein
 maintainer_email: seth.bluestein@phila.gov
 notes: "This data set is a list of elected Committee People by ward, division, and\
-  \ party.\r\n\r\nTrouble downloading or have questions about this City dataset? Visit\
-  \ the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ party."
 organization: City of Philadelphia
 resources:
 - description: 'Visit this site to download excel files for Democratic and Republican

--- a/_datasets/election-board-who-worked-on-election-day.md
+++ b/_datasets/election-board-who-worked-on-election-day.md
@@ -7,8 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: Seth Bluestein
 maintainer_email: seth.bluestein@phila.gov
 notes: "This data reflects which Election Board Officials worked on Election Day and\
-  \ received payment for their services.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ received payment for their services."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/election-results.md
+++ b/_datasets/election-results.md
@@ -7,8 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Data for both primary and general elections, 2002 - present.  Includes separate\
-  \ files for initial results and certified results.\r\n\r\nTrouble downloading or\
-  \ have questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ files for initial results and certified results."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/empowerment-zones.md
+++ b/_datasets/empowerment-zones.md
@@ -15,9 +15,7 @@ notes: "Data includes commercial and industrial zones, i.e. areas with specific 
   \ special amenities (tax incentives, loans/grants) meant to attract and support\
   \ businesses in blighted areas. Blighted areas are defined as meeting one of seven\
   \ city mandated criteria, including unsafe, unsanitary and inadequate conditions;\
-  \ economically or socially undesirable land use; and faulty street and lot layout.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ economically or socially undesirable land use; and faulty street and lot layout."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/enterprise-zones.md
+++ b/_datasets/enterprise-zones.md
@@ -17,9 +17,7 @@ notes: "Please note that the enterprise zones expired in the early 2000s, theref
   \ areas with specific federal enterprise zone designation meant to attract and support\
   \ businesses in blighted areas. Blighted areas are defined as meeting one of seven\
   \ city mandated criteria, including unsafe, unsanitary and inadequate conditions;\
-  \ economically or socially undesirable land use; and faulty street and lot layout.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ economically or socially undesirable land use; and faulty street and lot layout."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/exterior-violation-cleanups.md
+++ b/_datasets/exterior-violation-cleanups.md
@@ -7,9 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Dates and locations of when lots were cleaned (removing weeds, debris, etc.)\
-  \ through the City of Philadelphia's Community Life Improvement Program.\r\n\r\n\
-  Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ through the City of Philadelphia's Community Life Improvement Program."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/farmers-markets-locations.md
+++ b/_datasets/farmers-markets-locations.md
@@ -8,8 +8,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "Locations of farmers markets in Philadelphia.\r\n\r\nTrouble downloading or\
-  \ have questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Locations of farmers markets in Philadelphia."
 organization: City of Philadelphia
 resources:
 - description: "\r\n"

--- a/_datasets/fatal-crashes.md
+++ b/_datasets/fatal-crashes.md
@@ -14,9 +14,7 @@ notes: "This data set shows all fatal crashes and their investigative outcomes f
   \ the location of where crashes are initially _reported_ whereas OTIS' crash data\
   \ involves further investigation to confirm initial reports. If you want to analyze\
   \ the location of crashes in Philadelphia, use OTIS' dataset. If you want to understand\
-  \ the investigative outcomes of crashes, use the PPD dataset.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ the investigative outcomes of crashes, use the PPD dataset."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/fema-flood-plain.md
+++ b/_datasets/fema-flood-plain.md
@@ -5,9 +5,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
-notes: "Federal Emergency Management Administration (FEMA) data clipped to Philadelphia.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)\r\n"
+notes: "Federal Emergency Management Administration (FEMA) data clipped to Philadelphia.\r\n"
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As released by FEMA'

--- a/_datasets/fire-department-facilities.md
+++ b/_datasets/fire-department-facilities.md
@@ -10,8 +10,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Locations of Philadelphia Fire Department stations. Data originates from the\
-  \ City of Philadelphia Fire Department.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ City of Philadelphia Fire Department."
 organization: City of Philadelphia
 resources:
 - description: "Update Frequency:  as needed\r\n"

--- a/_datasets/flu-shot-clinic-schedule-and-locations.md
+++ b/_datasets/flu-shot-clinic-schedule-and-locations.md
@@ -10,9 +10,7 @@ maintainer: Public Health
 maintainer_email: ''
 notes: "Flu shot clinic schedule and locations for the City of Philadelphia. Locations\
   \ include Philadelphia Department of Public Health District Health Centers, federally\
-  \ qualified health centers and community flu clinics.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ qualified health centers and community flu clinics."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Annually'

--- a/_datasets/green-stormwater-infrastructure-planning-districts.md
+++ b/_datasets/green-stormwater-infrastructure-planning-districts.md
@@ -6,8 +6,7 @@ license: Other (City of Philadelphia)
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 notes: "District planning areas for Green City, Clean Waters stormwater management\
-  \ strategic planning. \r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ strategic planning. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/green-stormwater-infrastructure-private-projects.md
+++ b/_datasets/green-stormwater-infrastructure-private-projects.md
@@ -8,8 +8,7 @@ maintainer_email: raymond.pierdomenico@phila.gov
 notes: "Private Green Stormwater Infrastructure Project data in a tabular relational\
   \ database. Location point data is digitized manually with a tracking number. Tabular\
   \ data is queried and joined to point feature class before export to GEODB2 SDE\
-  \ databases.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ databases."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/green-stormwater-infrastructure-public-projects.md
+++ b/_datasets/green-stormwater-infrastructure-public-projects.md
@@ -6,8 +6,7 @@ license: Other (City of Philadelphia)
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 notes: "Point and line geometric features representing planned and completed Green\
-  \ Stormwater Infrastructure (GSI).\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Stormwater Infrastructure (GSI)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/health-centers.md
+++ b/_datasets/health-centers.md
@@ -7,8 +7,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "The location of primary care health centers.\r\n\r\nTrouble downloading or\
-  \ have questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "The location of primary care health centers."
 organization: City of Philadelphia
 resources:
 - description: "\r\n"

--- a/_datasets/healthy-chinese-takeout.md
+++ b/_datasets/healthy-chinese-takeout.md
@@ -20,8 +20,7 @@ notes: "Healthy Chinese Takeout participants as of 2/5/15. The Philadelphia Heal
   \ other retailers. To date, 200 Chinese take-out restaurants have enrolled in the\
   \ initiative, participated in a low-sodium healthy cooking training with a professional\
   \ chef, and received education about complying with the Tobacco Youth Sales Law.\
-  \ \r\n\r\nTrouble downloading or have questions about this City dataset? Visit the\
-  \ [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/healthy-corner-store-locations.md
+++ b/_datasets/healthy-corner-store-locations.md
@@ -11,8 +11,7 @@ maintainer: ''
 maintainer_email: ''
 notes: "This dataset contains location data for both Healthy Corner and Enhanced Healthy\
   \ Corner Store. It is currently being updated. Please visit [Food Fit Philly](http://foodfitphilly.org/eat-healthy-on-a-budget/)\
-  \ for information in the interim. \r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ for information in the interim. "
 organization: City of Philadelphia
 resources:
 - description: A webpage of available resources for finding healthy food.

--- a/_datasets/healthy-start-community-resource-centers.md
+++ b/_datasets/healthy-start-community-resource-centers.md
@@ -8,8 +8,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Street location, hours and contact information of PDPH-affiliated HealthyStart\
-  \ Community Resource Centers.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Community Resource Centers."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/heat-vulnerability-by-census-tract.md
+++ b/_datasets/heat-vulnerability-by-census-tract.md
@@ -9,8 +9,7 @@ license: Other (City of Philadelphia)
 maintainer: Alexandra Skula
 maintainer_email: alexandra.skula@phila.gov
 notes: "Describes heat vulnerability by census tract incorporating exposure and sensitivity\
-  \ indicators.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ indicators."
 organization: City of Philadelphia
 resources:
 - description: By Census Tracy (CT)

--- a/_datasets/highway-districts.md
+++ b/_datasets/highway-districts.md
@@ -10,9 +10,7 @@ maintainer: Michael Matela
 maintainer_email: michael.matela@phila.gov
 notes: "Please note that the dataset below is a snapshot of data captured at one time\
   \ and does not receive regular updates.\r\n\r\nThe Highway Districts dataset shows\
-  \ the boundaries of highway districts used for managing maintenance of roads. \r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ the boundaries of highway districts used for managing maintenance of roads. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/highway-sections.md
+++ b/_datasets/highway-sections.md
@@ -10,8 +10,7 @@ notes: "This layer delineates the fifty-six sections of the Highway Division of 
   \ The section layer was developed to aid the Highway Division in the planning, organizing,\
   \ and maintaining of the streets within each of the six districts. Examples of maintenance\
   \ include: paving, snow removal, concrete maintenance, and the monitoring/repairing\
-  \ of ditches and potholes.\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ of ditches and potholes."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/highway-subsections.md
+++ b/_datasets/highway-subsections.md
@@ -7,8 +7,7 @@ maintainer_email: michael.matela@phila.gov
 notes: "The subsection layer was developed to aid the Highway Division in the planning,\
   \ organizing, and maintaining of the streets within each of the fifty-six sections.\
   \  Examples include: paving, snow removal, concrete maintenance, and the monitoring/repairing\
-  \ of ditches and potholes. \r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ of ditches and potholes. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/historic-streams.md
+++ b/_datasets/historic-streams.md
@@ -6,8 +6,7 @@ license: Other (City of Philadelphia)
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 notes: "Philadelphia streams as mapped by Charles Ellet in 1842 and Previous study\
-  \ of historic streams conducted by PWD.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ of historic streams conducted by PWD."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/historic-streets.md
+++ b/_datasets/historic-streets.md
@@ -6,9 +6,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
-notes: "To map older streets with historical value in the City of Philadelphia.\r\n\
-  \r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "To map older streets with historical value in the City of Philadelphia."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/homes-saved.md
+++ b/_datasets/homes-saved.md
@@ -14,8 +14,7 @@ notes: "To prevent homeowners from becoming homeless due to foreclosure, the Cit
   \ foreclosure have an opportunity to meet with their lenders to negotiate an alternative\
   \ to foreclosure with City-funded housing counseling, outreach, a hotline and legal\
   \ assistance. Working together, the City and the Court have created and implemented\
-  \ a national model.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ a national model."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/housing-counseling-agencies.md
+++ b/_datasets/housing-counseling-agencies.md
@@ -11,9 +11,7 @@ notes: "OHCD has long supported neighborhood-based and citywide organizations of
   \ housing counseling services to low- and moderate-income people. OHCD-funded services\
   \ provided by these agencies include mortgage counseling, default and delinquency\
   \ counseling, tenant support and housing consumer education. Through these services\
-  \ prospective homeowners can avoid predatory loans, a significant cause of foreclosure.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ prospective homeowners can avoid predatory loans, a significant cause of foreclosure."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/hydrology.md
+++ b/_datasets/hydrology.md
@@ -14,9 +14,7 @@ maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 notes: "Locations of surface water features (rivers, creeks, ponds, reservoirs) and\
   \ water beneath city bridges and adjacent to city borders. Separate files are available\
-  \ for each waterbody (and watershed) in KML form, or as a whole in Shapefile form.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ for each waterbody (and watershed) in KML form, or as a whole in Shapefile form."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/impervious-surfaces.md
+++ b/_datasets/impervious-surfaces.md
@@ -14,8 +14,7 @@ maintainer: Brian Ivey
 maintainer_email: brian.ivey@phila.gov
 notes: "This is one of the planimetric coverages developed as part of the aerial survey\
   \ project of 1996 and updated using new aerial photography collected between 25\
-  \ March 2004 and 23 April 2004.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ March 2004 and 23 April 2004."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/indego-bike-share-stations.md
+++ b/_datasets/indego-bike-share-stations.md
@@ -12,8 +12,7 @@ maintainer: ''
 maintainer_email: ''
 notes: "Data relating to the Indego BikeShare program, including station locations\
   \ and the number of available bikes. More information about the program is available\
-  \ at:\r\nhttps://www.rideindego.com/about/data/\r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ at:\r\nhttps://www.rideindego.com/about/data/"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/indego-bike-share-trips.md
+++ b/_datasets/indego-bike-share-trips.md
@@ -10,9 +10,7 @@ maintainer: ''
 maintainer_email: ''
 notes: "Data relating to the Indego BikeShare program, including station locations\
   \ and the number of available bikes. More information about the program is available\
-  \ at: https://www.rideindego.com/about/data/\r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](https://groups.google.com/forum/#!forum/opendataphilly)\r\
-  \n\r\n"
+  \ at: https://www.rideindego.com/about/data/"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/instore-forgivable-loan-program.md
+++ b/_datasets/instore-forgivable-loan-program.md
@@ -7,9 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Contains information about the applicant, business, project, and costs. Used\
-  \ for tracking completed projects; including tracking amounts paid.\r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ for tracking completed projects; including tracking amounts paid."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/intersection-controls.md
+++ b/_datasets/intersection-controls.md
@@ -5,9 +5,7 @@ license: Other (City of Philadelphia)
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 notes: "This layer identifies the active intersection controls for the Street Lighting\
-  \ and Traffic Engineering Divisions of the City of Philadelphia Streets Department.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ and Traffic Engineering Divisions of the City of Philadelphia Streets Department."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/land-use.md
+++ b/_datasets/land-use.md
@@ -17,9 +17,7 @@ notes: "City of Philadelphia land use as ascribed to individual parcel boundarie
   \ as residential, commercial or industrial. Each unit of land is assigned one of\
   \ nine major classifications of land use (2-digit code), and where possible a more\
   \ narrowly defined sub-classification (3-digit code). The land use feature class\
-  \ has been field checked and corrected for the following Planning Districts. \r\n\
-  \r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ has been field checked and corrected for the following Planning Districts. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/landcare-program.md
+++ b/_datasets/landcare-program.md
@@ -9,9 +9,7 @@ maintainer: Mark Dodds
 maintainer_email: mark.dodds@phila.gov
 notes: "Data reflecting properties cleaned and greened through the LandCare program\
   \ - a joint program between the Division of Housing and Community Development (DHCD)\
-  \ and the Pennsylvania Horticultural Society (PHS).  \r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ and the Pennsylvania Horticultural Society (PHS). "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/language-services-usage.md
+++ b/_datasets/language-services-usage.md
@@ -7,9 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: maria.giraldo-gallo@phila.gov
 maintainer_email: maria.giraldo-gallo@phila.gov
 notes: "This dataset tracks usage of the City's language access services through contracts\
-  \ with external vendors for translation and interpretation. \r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ with external vendors for translation and interpretation."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/large-building-energy-benchmarking-data.md
+++ b/_datasets/large-building-energy-benchmarking-data.md
@@ -11,8 +11,7 @@ maintainer_email: benchmarkinghelp@phila.gov
 notes: "This dataset contains annual building and performance data for those properties\
   \ required to report. Property data is pulled from the Office of Property Assessment.\
   \ Energy and water data is self-reported by building owners using the EPA Portfolio\
-  \ Manager tool. This data will be updated annually.\r\n\r\nTrouble downloading or\
-  \ have questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Manager tool. This data will be updated annually."
 organization: City of Philadelphia
 resources:
 - description: Mapping and visualization application developed by the Mayor's Office

--- a/_datasets/leaf-collection-areas.md
+++ b/_datasets/leaf-collection-areas.md
@@ -7,9 +7,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
-notes: "To identify boundaries for City Leaf Collection Services.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+notes: "To identify boundaries for City Leaf Collection Services."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-appeals-of-code-violations-and-permit-refusals.md
+++ b/_datasets/licenses-and-inspections-appeals-of-code-violations-and-permit-refusals.md
@@ -15,8 +15,7 @@ notes: "The Department of Licenses and Inspections accepts applications for appe
   \ and what the status/results of the court proceedings are. Some Appeal numbers\
   \ could have multiple appeal types, so those are provided as a dataset below as\
   \ well. \r\n\r\nThe Board Decisions datasets shows the decisions made by the Appeal\
-  \ Boards (LIRB, ZBA, BBS).\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Boards (LIRB, ZBA, BBS)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-building-and-zoning-permits.md
+++ b/_datasets/licenses-and-inspections-building-and-zoning-permits.md
@@ -18,8 +18,7 @@ notes: "The Department of Licenses & Inspections reviews construction plans and 
   \ for all years.** \r\n\r\n**If you are comfortable with APIs, you can also use\
   \ the API links to access this data. You can learn more about how to use the API\
   \ at Carto\u2019s SQL API site and in the Carto guide in the section on making calls\
-  \ to the API.**\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ to the API.**"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-building-certifications.md
+++ b/_datasets/licenses-and-inspections-building-certifications.md
@@ -18,9 +18,7 @@ notes: "Certain buildings in the City of Philadelphia require periodic inspectio
   \ issues or system deficiencies identified during the corresponding inspection.\
   \ This dataset contains records related to these building certifications.\r\n\r\n\
   You can find out more information about [fire protection certifications](https://www.phila.gov/departments/department-of-licenses-and-inspections/inspections/fire-protection-certifications/)\
-  \ and [maintenance inspections](https://www.phila.gov/departments/department-of-licenses-and-inspections/inspections/maintenance-inspections/).\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ and [maintenance inspections](https://www.phila.gov/departments/department-of-licenses-and-inspections/inspections/maintenance-inspections/)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-business-licenses.md
+++ b/_datasets/licenses-and-inspections-business-licenses.md
@@ -14,9 +14,7 @@ notes: "Information regarding applications for licenses required by the City to 
   \ and contractors, require a license in order to practice their trade.\r\n\r\nInformation\
   \ includes license application type, applicant, property for which the license would\
   \ be issued, application date, issue date, and expiration date. Data is accurate;\
-  \ however, it may be misinterpreted by an unfamiliar user.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ however, it may be misinterpreted by an unfamiliar user."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-case-investigations.md
+++ b/_datasets/licenses-and-inspections-case-investigations.md
@@ -10,8 +10,7 @@ notes: "All investigations completed on a property with property maintenance vio
   \ for all years.** \r\n\r\n**If you are comfortable with APIs, you can also use\
   \ the API links to access this data. You can learn more about how to use the API\
   \ at Carto\u2019s SQL API site and in the Carto guide in the section on making calls\
-  \ to the API.**\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ to the API.**"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-clean-and-seal.md
+++ b/_datasets/licenses-and-inspections-clean-and-seal.md
@@ -5,8 +5,7 @@ license: Other (City of Philadelphia)
 maintainer: ligisteam@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 notes: "Address, date of abatement, and more for properties that have been cleaned\
-  \ and sealed by the L&I Clean & Seal Unit.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)\r\
+  \ and sealed by the L&I Clean & Seal Unit.\r\
   \n"
 organization: City of Philadelphia
 resources:

--- a/_datasets/licenses-and-inspections-code-violations.md
+++ b/_datasets/licenses-and-inspections-code-violations.md
@@ -12,8 +12,7 @@ notes: "Violations issued by the Department of Licenses and Inspections in refer
   \ all datasets for all years.** \r\n\r\n**If you are comfortable with APIs, you\
   \ can also use the API links to access this data. You can learn more about how to\
   \ use the API at Carto\u2019s SQL API site and in the Carto guide in the section\
-  \ on making calls to the API.**\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)\r\
+  \ on making calls to the API.**\r\
   \n"
 organization: City of Philadelphia
 resources:

--- a/_datasets/licenses-and-inspections-commercial-activity-licenses.md
+++ b/_datasets/licenses-and-inspections-commercial-activity-licenses.md
@@ -7,9 +7,7 @@ maintainer: ligisteam@phila.gov
 maintainer_email: LIGISTEAM@phila.gov
 notes: "Commercial Activity Licenses are required by entities doing business in the\
   \ City of Philadelphia. Information includes license number, application date, issuance\
-  \ date, applicant information, business entity name and other related information.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ date, applicant information, business entity name and other related information."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-complaints.md
+++ b/_datasets/licenses-and-inspections-complaints.md
@@ -8,8 +8,7 @@ notes: "Complaints that were entered via 311 or by an individual in the departme
   \ Complaints were formerly known as 'Service Requests' in L&I's old enterprise database\
   \ called 'Hansen', which was decommissioned in March 2020.\r\n\r\nEach row in the\
   \ table represents a single 'call'. Calls are sometimes bunched into one 'Complaint'\
-  \ all sharing the same unique number.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)\r\
+  \ all sharing the same unique number.\r\
   \n"
 organization: City of Philadelphia
 resources:

--- a/_datasets/licenses-and-inspections-district-offices.md
+++ b/_datasets/licenses-and-inspections-district-offices.md
@@ -7,8 +7,7 @@ maintainer_email: ligisteam@phila.gov
 notes: "Location and contact information for the L&I district offices.\r\n\r\nFor\
   \ all L&I data related inquiries contact ligisteam@phila.gov. For all other L&I\
   \ related services (including eCLIPSE troubleshooting) please contact Philly311:\r\
-  \n*Inside City Limits: 311\r\n*Outside City Limits: 215-686-8686\r\n\r\nTrouble\
-  \ downloading this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \n*Inside City Limits: 311\r\n*Outside City Limits: 215-686-8686"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-districts.md
+++ b/_datasets/licenses-and-inspections-districts.md
@@ -11,9 +11,7 @@ maintainer: Department of Licenses and Inspections
 maintainer_email: LIGISTEAM@phila.gov
 notes: "District Boundaries for the Department of Licenses & Inspections are pre 2014.\r\
   \nDistricts Broad refers to the five districts which contain their own district\
-  \ offices and are a method the department uses to assign and analyze work.\r\n\r\
-  \nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ offices and are a method the department uses to assign and analyze work."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/licenses-and-inspections-trade-licenses.md
+++ b/_datasets/licenses-and-inspections-trade-licenses.md
@@ -7,8 +7,7 @@ maintainer_email: LIGISTEAM@phila.gov
 notes: "Information regarding individuals who have applied for trades licenses such\
   \ as General Contractor, Master Plumber, and more. Information includes the individual's\
   \ name, license number, license status issue date, expiration date, company name,\
-  \ and revenue code.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ and revenue code."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/lidar-las-data.md
+++ b/_datasets/lidar-las-data.md
@@ -11,8 +11,7 @@ license: Other (City of Philadelphia)
 maintainer: Office of Innovation & Technology
 maintainer_email: maps@phila.gov
 notes: "LiDAR and LAS data was gathered for the City of Philadelphia in April 2008,\
-  \ April 2010 and April 2018.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ April 2010 and April 2018."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/litter-index.md
+++ b/_datasets/litter-index.md
@@ -9,9 +9,7 @@ license: Other (City of Philadelphia)
 maintainer: cleanphl@phila.gov
 maintainer_email: cleanphl@phila.gov
 notes: "The Litter Index is used to compare the relative cleanliness of different\
-  \ areas of the city of Philadelphia. This data will be updated annually.\r\n\r\n\
-  Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ areas of the city of Philadelphia. This data will be updated annually."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/major-watersheds-philadelphia.md
+++ b/_datasets/major-watersheds-philadelphia.md
@@ -14,8 +14,7 @@ notes: "Polygon feature class representing major watersheds in Philadelphia. Dat
   \ was developed originally from either USGS and the 2004 Sanborn DEM (digital elevation\
   \ model) using ArcHydro watershed extraction tools. Major Watersheds are dissolved\
   \ from subshed boundaries which reflect surface flow in relationship to stormwater\
-  \ inlets and outfalls.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ inlets and outfalls."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/major-watersheds-regional.md
+++ b/_datasets/major-watersheds-regional.md
@@ -14,8 +14,7 @@ notes: "Polygon feature class representing major watersheds in Philadelphia. Dat
   \ was developed originally from either USGS and the 2004 Sanborn DEM (digital elevation\
   \ model) using ArcHydro watershed extraction tools. Major Watersheds are dissolved\
   \ from subshed boundaries which reflect surface flow in relationship to stormwater\
-  \ inlets and outfalls.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ inlets and outfalls."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/neighborhood-advisory-committees-nacs.md
+++ b/_datasets/neighborhood-advisory-committees-nacs.md
@@ -8,9 +8,7 @@ maintainer: Portia Egan
 maintainer_email: portia.egan@phila.gov
 notes: "DHCD\u2019s Neighborhood Advisory Committee (NAC) Program offers community-based\
   \ non-profit organizations the opportunity to lead and engage neighborhood residents\
-  \ in activities that support the City\u2019s core objectives.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ in activities that support the City\u2019s core objectives."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/neighborhood-food-retail.md
+++ b/_datasets/neighborhood-food-retail.md
@@ -11,9 +11,7 @@ notes: "This dataset is derived from the Neighborhood Food Retail in Philadelphi
   \ report. The [report, and accompanying online resource gallery](http://foodfitphilly.org/NeighborhoodFoodRetail/),\
   \ looks at neighborhood availability of \"high-produce supply stores\u201D (e.g.,\
   \ supermarkets, produce stores, farmers\u2019 markets) in relation to \u201Clow-produce\
-  \ supply stores\u201D (like dollar stores, pharmacies, and convenience stores).\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ supply stores\u201D (like dollar stores, pharmacies, and convenience stores)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/neighborhood-resources.md
+++ b/_datasets/neighborhood-resources.md
@@ -7,9 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 notes: "Dataset with the contact information for Housing Counseling Agencies, Neighborhood\
-  \ Advisory Committees, and Neighborhood Energy Centers.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)."
+  \ Advisory Committees, and Neighborhood Energy Centers.."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/non-thru-streets-for-trucks.md
+++ b/_datasets/non-thru-streets-for-trucks.md
@@ -8,9 +8,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
-notes: "To map streets with no through trucks in the City of Philadelphia. \r\n\r\n\
-  Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "To map streets with no through trucks in the City of Philadelphia. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/oeo-registry-of-certified-minoritywomendisable-owned-business-enterprises.md
+++ b/_datasets/oeo-registry-of-certified-minoritywomendisable-owned-business-enterprises.md
@@ -9,8 +9,7 @@ maintainer: ''
 maintainer_email: ''
 notes: "A database of all Minority/Women/Disable Owned (MWD) owned businesses that\
   \ are registered with the City of Philadelphia's Office of Economic Opportunity\
-  \ (OEO).\r\n\r\nTrouble downloading or have questions about this City dataset? Visit\
-  \ the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ (OEO)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/openmaps.md
+++ b/_datasets/openmaps.md
@@ -21,8 +21,7 @@ maintainer: CityGeo
 maintainer_email: maps@phila.gov
 notes: "Explore Philadelphia's most popular open geographic data in one easy to use\
   \ mapping tool. This tool was built by the City's Office of Innovation and Technology's\
-  \ CityGeo team.\r\n\r\nTrouble using or have questions about this City application?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ CityGeo team."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/outdoor-advertising.md
+++ b/_datasets/outdoor-advertising.md
@@ -5,9 +5,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: LIGISTEAM@phila.gov
 notes: "Locational and relevant attribute data pertaining to billboard and outdoor\
-  \ advertising locations throughout the City of Philadelphia.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ advertising locations throughout the City of Philadelphia."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parking-meter-kiosk-inventory.md
+++ b/_datasets/parking-meter-kiosk-inventory.md
@@ -5,8 +5,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Raw data dump from the PPA including meter/kiosk manufacturer and model, as\
-  \ well as status.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ well as status."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parking-violations.md
+++ b/_datasets/parking-violations.md
@@ -10,8 +10,7 @@ notes: "**Please note that this is a very large dataset. To see all violations, 
   \ all datasets for all years.** \r\n\r\n**If you are comfortable with APIs, you\
   \ can also use the API links to access this data. You can learn more about how to\
   \ use the API at Carto\u2019s SQL API site and in the Carto guide in the section\
-  \ on making calls to the API.**\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ on making calls to the API.**"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parks-and-recreation-out-of-school-time-programs.md
+++ b/_datasets/parks-and-recreation-out-of-school-time-programs.md
@@ -7,9 +7,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "Philadelphia Parks and Recreation out-of-school time afterschool programs.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Philadelphia Parks and Recreation out-of-school time afterschool programs."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parks-and-recreation-ppr-trails.md
+++ b/_datasets/parks-and-recreation-ppr-trails.md
@@ -16,8 +16,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Linear representation of Philadelphia Parks and Recreation (PPR) trails. Not\
-  \ designed for networking. \r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ designed for networking. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parks-recreation-districts.md
+++ b/_datasets/parks-recreation-districts.md
@@ -11,8 +11,7 @@ maintainer_email: ''
 notes: "Polygon boundaries of Philadelphia Parks and Recreation (PPR) operational\
   \ districts as established by PPR's GIS staff and reviewed, revised, and approved\
   \ by PPR's executive staff. These boundaries were revised from boundaries that were\
-  \ in place in prior years.\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ in place in prior years."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/parks-recreation-program-sites.md
+++ b/_datasets/parks-recreation-program-sites.md
@@ -10,8 +10,7 @@ maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 notes: "Point location features for all PPR Program site locations. This dataset includes\
   \ recreation centers, playgrounds, older adult centers, swimming pools, and environmental\
-  \ education centers.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ education centers."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/paving-plan.md
+++ b/_datasets/paving-plan.md
@@ -7,9 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 notes: "City of Philadelphia paving plan for 2015 that displays paving project funding,\
-  \ City - Local Funding, City - Federal Funding, and State Funding.\r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)\r\n\r\n"
+  \ City - Local Funding, City - Federal Funding, and State Funding.\r\n\r\n"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pennsylvania-state-house-of-representatives-districts.md
+++ b/_datasets/pennsylvania-state-house-of-representatives-districts.md
@@ -5,9 +5,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "Please refer to [PA's open data for the State House Representative Districts](https://data.pa.gov/Geospatial-Data/Pennsylvania-House-Districts-Boundaries/in5u-czi3).\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Please refer to [PA's open data for the State House Representative Districts](https://data.pa.gov/Geospatial-Data/Pennsylvania-House-Districts-Boundaries/in5u-czi3)."
 organization: City of Philadelphia
 resources: []
 schema: default

--- a/_datasets/people-released-to-philadelphia-from-prison-jail.md
+++ b/_datasets/people-released-to-philadelphia-from-prison-jail.md
@@ -12,8 +12,7 @@ notes: "This dataset includes people released to Philadelphia from the Philadelp
   \ not available, and makes up less than 2% of people released to Philadelphia in\
   \ the year analyzed. The dataset also only includes people released to Philadelphia\
   \ who have been charged with a criminal non-summary type offense in the Philadelphia\
-  \ adult criminal justice system.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ adult criminal justice system."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: Annually'

--- a/_datasets/percent-for-art-locations.md
+++ b/_datasets/percent-for-art-locations.md
@@ -9,8 +9,7 @@ license: Other (City of Philadelphia)
 maintainer: Dan Whaland
 maintainer_email: daniel.whaland@phila.gov
 notes: "Locations and basic information on public art that is part of the Percent\
-  \ for Art program. Updated as needed. \r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ for Art program. Updated as needed. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-basemaps.md
+++ b/_datasets/philadelphia-basemaps.md
@@ -9,8 +9,7 @@ license: Other (City of Philadelphia)
 maintainer: maps@phila.gov
 maintainer_email: maps@phila.gov
 notes: "Basemaps of the Philadelphia area, including from the Department of Records.\
-  \ \r\n\r\nTrouble downloading or have questions about this City dataset? Visit the\
-  \ [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-child-blood-lead-levels.md
+++ b/_datasets/philadelphia-child-blood-lead-levels.md
@@ -12,9 +12,7 @@ notes: "This dataset includes the number of newly identified (incident) children
   \ the percent of children screened with BLLs \u22655 \xB5g/dL. The ZIP code data\
   \ is for 2015 and the census tract data is for 2013-2015.\r\n\r\nCell counts with\
   \ missing values are those with less than six observations, which was truncated\
-  \ to ensure confidentiality. Cells with values of zero were included.\r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ to ensure confidentiality. Cells with values of zero were included."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-code-and-home-rule-charter.md
+++ b/_datasets/philadelphia-code-and-home-rule-charter.md
@@ -10,8 +10,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Raw text and other formats available of the City of Philadelphia Municipal\
-  \ Code and City Charter.\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Code and City Charter."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-esl-english-as-a-second-language-class-locations.md
+++ b/_datasets/philadelphia-esl-english-as-a-second-language-class-locations.md
@@ -6,9 +6,7 @@ maintainer: Office of Adult Education
 maintainer_email: catherine.freimiller@phila.gov
 notes: "Location of English as a Second Language (ESL) classes in Philadelphia. To\
   \ find the best site to visit for ESL classes, or to enroll in training for volunteers\
-  \ to become an ESL tutor, please contact the Office of Adult Education at 215-686-5250.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ to become an ESL tutor, please contact the Office of Adult Education at 215-686-5250."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-hospitals.md
+++ b/_datasets/philadelphia-hospitals.md
@@ -7,9 +7,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "A list of hospitals and their location in Philadelphia. \r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+notes: "A list of hospitals and their location in Philadelphia."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-household-internet-assessment-survey.md
+++ b/_datasets/philadelphia-household-internet-assessment-survey.md
@@ -8,8 +8,7 @@ license: Other (City of Philadelphia)
 maintainer: Juliet Fink-Yates
 maintainer_email: juliet.fink-yates@phila.gov
 notes: "A survey assessment on home broadband and device access in the City of Philadelphia.\
-  \ \r\n\r\nTrouble downloading or have questions about this City dataset? Visit the\
-  \ [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-land-cover-raster.md
+++ b/_datasets/philadelphia-land-cover-raster.md
@@ -15,8 +15,7 @@ notes: "The Philadelphia Land Cover Raster provides data on the types of surface
   \ was intended to demonstrate tree canopy levels in Philadelphia. When tree canopy\
   \ covers another surface type, that area is placed in the tree canopy category.\
   \ The data was gathered with the assistance of the University of Vermont Spatial\
-  \ Analysis Laboratory.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Analysis Laboratory."
 organization: City of Philadelphia
 resources:
 - description: Multiple download formats available as well as ArcGIS services and

--- a/_datasets/philadelphia-lobbying-information-system-app.md
+++ b/_datasets/philadelphia-lobbying-information-system-app.md
@@ -22,9 +22,7 @@ notes: "The Philadelphia Lobbying Information System is a searchable database of
   \ this data is anyone with an interest in the people lobbying City government. \
   \ The data collected by PLIS is a public record intended to make the legislative\
   \ and executive process more transparent by providing the public with a clear picture\
-  \ of all of the outside interests involved in policy discussions.\r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ of all of the outside interests involved in policy discussions."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-pennsylvania-state-senatorial-districts.md
+++ b/_datasets/philadelphia-pennsylvania-state-senatorial-districts.md
@@ -5,9 +5,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "Please refer to [PA's open data for the State Senate Districts](https://data.pa.gov/Geospatial-Data/Pennsylvania-Senatorial-Districts-Boundaries/52q9-9t9c).\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Please refer to [PA's open data for the State Senate Districts](https://data.pa.gov/Geospatial-Data/Pennsylvania-Senatorial-Districts-Boundaries/52q9-9t9c)."
 organization: City of Philadelphia
 resources: []
 schema: default

--- a/_datasets/philadelphia-properties-and-assessment-history.md
+++ b/_datasets/philadelphia-properties-and-assessment-history.md
@@ -13,8 +13,7 @@ notes: "***OPA is currently updating its data files. Some of the information in 
   \ more information on [how OPA assesses property and their reports](https://www.phila.gov/departments/office-of-property-assessment/resources/)\
   \ on the quality of assessments. \r\n\r\n***This data updates nightly. Please ignore\
   \ the 'created by' date below - the date of August 2015 shows when this webpage,\
-  \ not the data, was created.*** Trouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ not the data, was created.***"
 organization: City of Philadelphia
 resources:
 - description: "***This data updates nightly. Please ignore the 'created by' date\

--- a/_datasets/philadelphia-registered-historic-districts.md
+++ b/_datasets/philadelphia-registered-historic-districts.md
@@ -11,9 +11,7 @@ maintainer_email: darshna.patel@phila.gov
 notes: "Historic districts listed on the Philadelphia Register. Data was updated by\
   \ the Philadelphia City Planning Commission in August 2017.  The public can confirm\
   \ a property\u2019s historic status by contacting the Historical Commission at 215-686-7660.\r\
-  \n\r\nYou can also download a dataset of the [Historic sites](https://www.opendataphilly.org/dataset/philadelphia-registered-historic-sites).\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \n\r\nYou can also download a dataset of the [Historic sites](https://www.opendataphilly.org/dataset/philadelphia-registered-historic-sites)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-registered-historic-properties.md
+++ b/_datasets/philadelphia-registered-historic-properties.md
@@ -16,9 +16,7 @@ maintainer_email: ''
 notes: "Historic sites listed on the Philadelphia Register. Data was updated by the\
   \ Philadelphia City Planning Commission in July 2017.  The public should confirm\
   \ a property\u2019s historic status by contacting the Historical Commission at 215-686-7660.\r\
-  \n\r\nYou can also download a dataset of the [Historic districts](https://www.opendataphilly.org/dataset/philadelphia-registered-historic-districts).\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \n\r\nYou can also download a dataset of the [Historic districts](https://www.opendataphilly.org/dataset/philadelphia-registered-historic-districts)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-tree-inventory.md
+++ b/_datasets/philadelphia-tree-inventory.md
@@ -7,9 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: Chris Park
 maintainer_email: Chris.Park@Phila.gov
 notes: "A comprehensive inventory of all trees within the limits of the City of Philadelphia.\
-  \ This dataset is a snapshot in time from 2021 and will update yearly. \r\n\r\n\
-  Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ This dataset is a snapshot in time from 2021 and will update yearly. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/philadelphia-universities-and-colleges.md
+++ b/_datasets/philadelphia-universities-and-colleges.md
@@ -7,8 +7,7 @@ maintainer: ''
 maintainer_email: ''
 notes: "The purpose of this dataset is to provide the geographic locations of the\
   \ college and universities in Philadelphia along with their attribute data attached\
-  \ to each polygon.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)\r\
+  \ to each polygon.\r\
   \n"
 organization: City of Philadelphia
 resources:

--- a/_datasets/philadelphia-vital-statistics-mortality-deaths.md
+++ b/_datasets/philadelphia-vital-statistics-mortality-deaths.md
@@ -21,9 +21,7 @@ notes: "Vital Statistics tables that contain aggregate metrics on the mortality 
   \ at the city and planning district levels of geography as well. [Population metrics](https://www.opendataphilly.org/dataset/philadelphia-vital-statistics-population-metrics)\
   \ are provided at the city, planning district, and census tract levels of geography.\
   \ Please refer to [this technical notes document](https://metadata.phila.gov/#home/datasetdetails/61c23fb963d616001ef54695/representationdetails/624cb0c4782b6a001ebc26f3/kn-asset/142-534-251-6279872beb52cc001e87008f/technicalnotesformetadata5.9.22.pdf)\
-  \ to access detailed technical notes and variable definitions.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ to access detailed technical notes and variable definitions."
 organization: City of Philadelphia
 resources:
 - description: Interactive maps and charts of vital statistics and trends in natality

--- a/_datasets/philadelphia-vital-statistics-natality-births.md
+++ b/_datasets/philadelphia-vital-statistics-natality-births.md
@@ -24,9 +24,7 @@ notes: "Vital Statistics tables that contain aggregate metrics on the natality (
   \ are provided at the city, planning district, and census tract levels of geography.\
   \ Please refer to the metadata links below for variable definitions and [this technical\
   \ notes document](https://metadata.phila.gov/#home/datasetdetails/61c23fb963d616001ef54695/representationdetails/624cb0c4782b6a001ebc26f3/kn-asset/142-534-251-6279872beb52cc001e87008f/technicalnotesformetadata5.9.22.pdf)\
-  \ to access detailed technical notes about the datasets.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ to access detailed technical notes about the datasets."
 organization: City of Philadelphia
 resources:
 - description: Interactive maps and charts of vital statistics and trends in natality

--- a/_datasets/philadelphia-vital-statistics-population-metrics.md
+++ b/_datasets/philadelphia-vital-statistics-population-metrics.md
@@ -22,9 +22,7 @@ notes: "Population metrics are provided at the census tract, planning district, 
   \ of Philadelphia residents as  well as [social determinants of health metrics](https://www.opendataphilly.org/dataset/philadelphia-vital-statistics-social-determinants-of-health-sdoh)\
   \ at the city and planning district levels of geography.  Please refer to the metadata\
   \ links below for variable definitions and [this technical notes document](https://metadata.phila.gov/#home/datasetdetails/61c23fb963d616001ef54695/representationdetails/624cb0c4782b6a001ebc26f3/kn-asset/142-534-251-6279872beb52cc001e87008f/technicalnotesformetadata5.9.22.pdf)\
-  \ to access detailed technical notes and variable definitions.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)\r\n"
+  \ to access detailed technical notes and variable definitions.\r\n"
 organization: City of Philadelphia
 resources:
 - description: Interactive maps and charts of vital statistics and trends in natality

--- a/_datasets/philadelphia-vital-statistics-social-determinants-of-health-sdoh.md
+++ b/_datasets/philadelphia-vital-statistics-social-determinants-of-health-sdoh.md
@@ -24,8 +24,7 @@ notes: "Social determinants of health metrics at the city and planning district 
   \ and [mortality (deaths)](https://www.opendataphilly.org/dataset/philadelphia-vital-statistics-mortality-deaths)\
   \ by planning district or citywide. [Population metrics](https://www.opendataphilly.org/dataset/philadelphia-vital-statistics-population-metrics)\
   \ are provided at the city, planning district, and census tract levels of geography.\
-  \ \r\n\r\nTrouble downloading or have questions about this City dataset? Visit the\
-  \ [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)\r\n"
+  \r\n"
 organization: City of Philadelphia
 resources:
 - description: Interactive maps and charts of vital statistics and trends in natality

--- a/_datasets/philadox-property-documents.md
+++ b/_datasets/philadox-property-documents.md
@@ -20,9 +20,7 @@ notes: "PhilaDox is an online database of documents filed with the City of Phila
   \ by grantor/grantee names, address, or county record book and page.  Scanned documents\
   \ can be downloaded as PDFs.\r\n\r\nFull access to PhilaDox records is available\
   \ with a daily, weekly, monthly, or annual subscription. More limited search for\
-  \ names and address is available for free public access.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ names and address is available for free public access."
 organization: City of Philadelphia
 resources:
 - description: Searchable database of deed and mortgage recordings.  Actual deeds

--- a/_datasets/philly-rising-boundaries.md
+++ b/_datasets/philly-rising-boundaries.md
@@ -13,8 +13,7 @@ maintainer_email: brian.ivey@phila.gov
 notes: "The boundaries of the four designated pilot areas included in the Philly Rising\
   \ program. Philly Rising focuses on areas with chronic quality of life concerns\
   \ and works with residents and community groups to address neighborhood issues.\
-  \ \r\n\r\nTrouble downloading or have questions about this City dataset? Visit the\
-  \ [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/phillyhistoryorg.md
+++ b/_datasets/phillyhistoryorg.md
@@ -20,8 +20,7 @@ notes: "PhillyHistory.org is an online database of historic photographs and maps
   \ intersection, place name, and neighborhood as well as keyword, date, collection,\
   \ topics, and other criteria. Images and maps are associated with a location using\
   \ the database's geocoding feature. Users can create a free account to save images,\
-  \ bookmark searches, and submit error reports.\r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ bookmark searches, and submit error reports."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/phlmaps.md
+++ b/_datasets/phlmaps.md
@@ -22,8 +22,7 @@ maintainer_email: maps@phila.gov
 notes: "The City of Philadelphia's ArcGIS Online organization that hosts references\
   \ to open data releases as feature services and AGO map applications shared with\
   \ the public.  Maintained by the City's Office of Innovation and Technology's CityGeo\
-  \ team.\r\n\r\nTrouble using or have questions about this City application? Visit\
-  \ the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ team."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/planning-districts.md
+++ b/_datasets/planning-districts.md
@@ -10,8 +10,7 @@ license: Other (City of Philadelphia)
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 notes: "To illustrate the outlines of the 18 Districts for Philadelphia2035 District\
-  \ Plans.\r\n\r\nTrouble downloading or have questions about this City dataset? Visit\
-  \ the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Plans."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/playstreets-locations.md
+++ b/_datasets/playstreets-locations.md
@@ -10,9 +10,7 @@ notes: "The streets (at the center of platystreet blocks) involved in the PPR Pl
   \ Program.  This program closes designated streets to traffic so that kids have\
   \ a safe place to play when school is out. A key feature of the program are the\
   \ nutritious meals and snacks provided to children. This is important during the\
-  \ summer months when school meals are not available.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ summer months when school meals are not available."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/police-athletic-league-pal-centers.md
+++ b/_datasets/police-athletic-league-pal-centers.md
@@ -9,8 +9,7 @@ license: Other (City of Philadelphia)
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 notes: "This data was developed for cartographic use -- specifically, as reference\
-  \ information for the Police Athletic League.\r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ information for the Police Athletic League."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/police-districts.md
+++ b/_datasets/police-districts.md
@@ -11,9 +11,7 @@ license: Other (City of Philadelphia)
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
 notes: "Police district boundaries. A police Captain is responsible for each district.\
-  \ Districts are subdivided into sectors. Several districts are aggregated into divisions.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Districts are subdivided into sectors. Several districts are aggregated into divisions."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/police-divisions.md
+++ b/_datasets/police-divisions.md
@@ -9,9 +9,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
-notes: "Police division boundaries.  Divisions are aggregations of police districts.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Police division boundaries.  Divisions are aggregations of police districts."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/police-service-areas.md
+++ b/_datasets/police-service-areas.md
@@ -12,9 +12,7 @@ maintainer_email: publicsafetygis@phila.gov
 notes: "There are currently 65 Police Service Areas (PSA) boundaries in Philadelphia\
   \ with two to four per District. These boundaries replaced a much smaller boundary,\
   \ Sectors in 2009. In several Districts, PSA's split Sector boundaries and therefore\
-  \ a historical comparison would not necessarily be accurate.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ a historical comparison would not necessarily be accurate."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/police-stations.md
+++ b/_datasets/police-stations.md
@@ -7,8 +7,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
-notes: "Locations of Police Stations.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Locations of Police Stations."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/political-ward-divisions.md
+++ b/_datasets/political-ward-divisions.md
@@ -14,8 +14,7 @@ maintainer: Darshna Patel
 maintainer_email: Darshna.Patel@phila.gov
 notes: "Boundaries of the ward divisions (subunits of wards) in Philadelphia. The\
   \ first two numbers of a four number division identifier indicates the ward in which\
-  \ the specific division is located.\r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ the specific division is located."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/political-wards.md
+++ b/_datasets/political-wards.md
@@ -14,9 +14,7 @@ notes: "Boundaries of wards (political units) in the City of Philadelphia. Data 
   \ developed by Philadelphia City Planning Commission. Each ward contains no fewer\
   \ than 10 and no more than 50 divisions. Ward leaders are elected by their party's\
   \ committeepeople. Learn more about Democratic Ward Leaders and Committeepeople\
-  \ : http://www.seventy.org/Resources_Ward_Leaders_and_Committeepeople.aspx\r\n\r\
-  \nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ : http://www.seventy.org/Resources_Ward_Leaders_and_Committeepeople.aspx"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/polling-places.md
+++ b/_datasets/polling-places.md
@@ -13,9 +13,7 @@ maintainer_email: seth.bluestein@phila.gov
 notes: "The locations of polling places in Philadelphia, along with parking code and\
   \ building accessibility code attribute markers. Data is originally provided by\
   \ the Philadelphia City Commissioners and is continuously updated in correspondence\
-  \ with the City Commissioners website, www.philadelphiavotes.com.\r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ with the City Commissioners website, www.philadelphiavotes.com."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-boat-launches.md
+++ b/_datasets/ppr-boat-launches.md
@@ -10,8 +10,7 @@ maintainer_email: ''
 notes: "Boat launches across the city are places where boats (kayaks, canoes, and\
   \ or motorboats) can be launched onto the Schuylkill River or Delaware River. This\
   \ dataset identifies the boat launches/ramps located on PPR property or boat launches\
-  \ PPR administers directly. \r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ PPR administers directly. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-building-structures.md
+++ b/_datasets/ppr-building-structures.md
@@ -8,8 +8,7 @@ license: Other (City of Philadelphia)
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 notes: "Footprints of buildings and structures located on Philadelphia Parks and Recreation\
-  \ (PPR) properties or utilized directly by PPR.\t\r\n\r\nTrouble downloading or\
-  \ have questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ (PPR) properties or utilized directly by PPR.\t"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-permittable-space.md
+++ b/_datasets/ppr-permittable-space.md
@@ -7,9 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: Andy Viren
 maintainer_email: andy.viren@phila.gov
 notes: "Locations within PPR that are permittable based on PPR team. Feature designed\
-  \ to link with Permitting Application for PPR. BETA Version.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ to link with Permitting Application for PPR. BETA Version."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-program-districts.md
+++ b/_datasets/ppr-program-districts.md
@@ -8,9 +8,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Polygon boundaries of PPR's program districts as established by PPR's GIS\
-  \ staff and reviewed, revised, and approved by PPR's executive staff.\r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ staff and reviewed, revised, and approved by PPR's executive staff."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-spraygrounds.md
+++ b/_datasets/ppr-spraygrounds.md
@@ -7,9 +7,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
-notes: "The location of spraygrounds in Philadelphia run by Parks and Recreation.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "The location of spraygrounds in Philadelphia run by Parks and Recreation."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ppr-swimming-pools.md
+++ b/_datasets/ppr-swimming-pools.md
@@ -7,9 +7,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
-notes: "The location of swimming pools in Philadelphia run by Parks and Recreation.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "The location of swimming pools in Philadelphia run by Parks and Recreation."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/professional-services-contracts.md
+++ b/_datasets/professional-services-contracts.md
@@ -16,9 +16,7 @@ notes: "The entire dataset for Professional Services Contracts by fiscal quarter
   \ City\u2019s professional services contracts in a searchable format and includes\
   \ a breakdown of contract dollars by vendor, department and service type. It also\
   \ features a \u201Cfrequently asked questions\u201D section to help users understand\
-  \ the available data: http://cityofphiladelphia.github.io/contracts/.  \r\n\r\n\
-  Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ the available data: http://cityofphiladelphia.github.io/contracts/.  "
 organization: City of Philadelphia
 resources:
 - description: '***To download:  click on the dataset url, which will open in a new

--- a/_datasets/property-tax-delinquencies.md
+++ b/_datasets/property-tax-delinquencies.md
@@ -9,9 +9,7 @@ maintainer: Mike Isard
 maintainer_email: mike.isard@phila.gov
 notes: "This is a dataset that shows the Philadelphia properties with tax delinquencies,\
   \ including those that are in payment agreements. An account is delinquent when\
-  \ Real Estate Tax is still unpaid on January 1 the following year the tax was due.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Real Estate Tax is still unpaid on January 1 the following year the tax was due."
 organization: City of Philadelphia
 resources:
 - description: Updated monthly

--- a/_datasets/pwd-customer-service-calls.md
+++ b/_datasets/pwd-customer-service-calls.md
@@ -9,8 +9,7 @@ maintainer_email: angeline.zamorski@phila.gov
 notes: "Every call received by the Customer Information Unit for issues like open\
   \ hydrants, cave ins, and more. Calls are categorized as to the type of issue at\
   \ hand. Includes outcomes of calls. Billing matters are referred to the Water Revenue\
-  \ Bureau.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Bureau."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pwd-geotechnical-tests.md
+++ b/_datasets/pwd-geotechnical-tests.md
@@ -13,9 +13,7 @@ notes: "BACKGROUND - The objective of geotechnical testing is to help determine 
   \ the footprint of each GSI system.\r\n\r\nUSING THE LAYER - The infiltration rates\
   \ and subsurface lithology results such as depth to bedrock and depth to groundwater\
   \ may be helpful for other users of this layer, but it is important to note that\
-  \ these values can vary widely from location to location, even for nearby sites.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ these values can vary widely from location to location, even for nearby sites."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pwd-stormwater-billing-parcels.md
+++ b/_datasets/pwd-stormwater-billing-parcels.md
@@ -6,9 +6,7 @@ license: Other (City of Philadelphia)
 maintainer: Larry Szarek
 maintainer_email: larry.szarek@phila.gov
 notes: "The primary purpose of PWD_PARCEL layer is to calculate parcel-based stormwater\
-  \ charges for PWD customers under the new parcel-based stormwater billing program.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ charges for PWD customers under the new parcel-based stormwater billing program."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/pwd-stream-sampling-locations.md
+++ b/_datasets/pwd-stream-sampling-locations.md
@@ -10,9 +10,7 @@ maintainer_email: raymond.pierdomenico@phila.gov
 notes: "Locations where PWD has conducted surface water quality sampling and other\
   \ types of stream assessments. Sampling activities may include water quality grab\
   \ sampling, habitat assessment, and sampling of invertebrates, fish and algae from\
-  \ wadeable streams. Not all assessment activities are performed at all sites.\r\n\
-  \r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ wadeable streams. Not all assessment activities are performed at all sites."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/railroad-lines.md
+++ b/_datasets/railroad-lines.md
@@ -6,8 +6,7 @@ maintainer: Brian Ivey
 maintainer_email: brian.ivey@phila.gov
 notes: "This is one of the planimetric coverages developed as part of the aerial survey\
   \ project of 1996 and updated using new aerial photography collected between 25\
-  \ March 2004 and 23 April 2004.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ March 2004 and 23 April 2004."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/rain-barrels.md
+++ b/_datasets/rain-barrels.md
@@ -7,8 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 notes: "Rain Barrels installed under PWD's Rain Barrel Workshop and Installation program,\
-  \ which ran from 2006 to 2014.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ which ran from 2006 to 2014."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/rain-check-installation-sites.md
+++ b/_datasets/rain-check-installation-sites.md
@@ -6,8 +6,7 @@ license: Other (City of Philadelphia)
 maintainer: Phil Pierdomenico
 maintainer_email: raymond.pierdomenico@phila.gov
 notes: "Rain Check is a Philadelphia Water Department program that helps residents\
-  \ manage stormwater and beautify their homes. \r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ manage stormwater and beautify their homes. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/rain-gauges.md
+++ b/_datasets/rain-gauges.md
@@ -7,8 +7,7 @@ maintainer: Edward Lennon, Jr.
 maintainer_email: edward.lennonjr@phila.gov
 notes: "The purpose of this data is to describe the Rain Gauges both locationally\
   \ and via their attributes. This data shows the location and attributes of Rain\
-  \ Gauges throughout the City of Philadelphia.\r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Gauges throughout the City of Philadelphia."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/real-estate-transfers.md
+++ b/_datasets/real-estate-transfers.md
@@ -22,9 +22,7 @@ notes: "The Department of Records (DOR) published data for all documents recorde
   \ We provide the CSV of All Years mostly for developers to use when coding.\r\n\
   If you are comfortable with APIs, you could also use the API links to access this\
   \ data. You can learn more about how to use the API at [Carto\u2019s SQL API site](https://carto.com/developers/sql-api/)\
-  \  and in the [Carto guide in the section on making calls to the API](https://carto.com/developers/sql-api/guides/making-calls/).**\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \  and in the [Carto guide in the section on making calls to the API](https://carto.com/developers/sql-api/guides/making-calls/).**"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/recyclebank-participation.md
+++ b/_datasets/recyclebank-participation.md
@@ -7,9 +7,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "Count of residents participating in the RecycleBank program by street segment.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Count of residents participating in the RecycleBank program by street segment."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/recycling-diversion-rate.md
+++ b/_datasets/recycling-diversion-rate.md
@@ -9,8 +9,7 @@ maintainer_email: max.steinbrenner@phila.gov
 notes: "Rate of recycling per rubbish/recycling district in total tons of recycling\
   \ divided by the total tons of rubbish (garbage) collected during the given time\
   \ period, either fiscal year, a fiscal year through a given quarter, or within one\
-  \ quarter.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ quarter."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/red-light-cameras.md
+++ b/_datasets/red-light-cameras.md
@@ -6,9 +6,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "Locations of red light cameras maintained by the Philadelphia Parking Authority.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Locations of red light cameras maintained by the Philadelphia Parking Authority."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/redevelopment-certified-areas.md
+++ b/_datasets/redevelopment-certified-areas.md
@@ -16,9 +16,7 @@ notes: "Development certified areas, i.e. areas deemed blighted and eligible for
   \ renewal by the Philadelphia City Planning Commission under the amended Pennsylvania\
   \ Urban Redevelopment Law. Blighted areas are defined as meeting one of seven city\
   \ mandated criteria, including unsafe, unsanitary and inadequate conditions; economically\
-  \ or socially undesirable land use; and faulty street and lot layout.\r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ or socially undesirable land use; and faulty street and lot layout."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/registered-community-gardens.md
+++ b/_datasets/registered-community-gardens.md
@@ -9,9 +9,7 @@ license: Other (City of Philadelphia)
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 notes: "Locations of community gardens throughout the City of Philadelphia that are\
-  \ registered with the Philadelphia Parks and Recreation's Urban Agriculture Team.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ registered with the Philadelphia Parks and Recreation's Urban Agriculture Team."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/registered-community-organizations-rco-boundaries.md
+++ b/_datasets/registered-community-organizations-rco-boundaries.md
@@ -10,8 +10,7 @@ maintainer: Pauline Loughlin
 maintainer_email: pauline.loughlin@phila.gov
 notes: "Boundaries of Registered Community Organizations (RCO) as established under\
   \ the City of Philadelphia Zoning Code enacted December 15, 2011 and made effective\
-  \ August 22, 2012.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ August 22, 2012."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/residency-waivers.md
+++ b/_datasets/residency-waivers.md
@@ -11,8 +11,7 @@ notes: "The table below shows which job positions have received a waiver from th
   \ fulfill certain residency requirements:\r\n-Exempt positions: You must move to\
   \ Philadelphia within six months after your appointment date.\r\n-Civil service\
   \ positions: you must live in Philadelphia for one year before your appointment\
-  \ date.\r\n\r\nTrouble downloading or have questions about this City dataset? Visit\
-  \ the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ date."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/residential-parking-permit-blocks.md
+++ b/_datasets/residential-parking-permit-blocks.md
@@ -6,8 +6,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly
-  Discussion Group](http://www.phila.gov/data/discuss/)
+notes: 
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/retrofitted-homes.md
+++ b/_datasets/retrofitted-homes.md
@@ -6,8 +6,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: mos@phila.gov
 maintainer_email: http://metadata.phila.gov/#home/datasetdetails/55f6dd9fb22cc14e01e7ec68/representationdetails/55f8574226c3115b5533017c/
-notes: Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly
-  Discussion Group](http://www.phila.gov/data/discuss/)
+notes: 
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/ryan-white-hiv-treatment-centers.md
+++ b/_datasets/ryan-white-hiv-treatment-centers.md
@@ -8,8 +8,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Street location, contact information and hours of PDPH-funded HIV Treatment\
-  \ Centers.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Centers."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/sanitation-areas.md
+++ b/_datasets/sanitation-areas.md
@@ -14,8 +14,7 @@ license: Other (City of Philadelphia)
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 notes: "Data includes the boundaries for city sanitation areas (which are aggregations\
-  \ of Sanitation Districts).\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ of Sanitation Districts)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/sanitation-collection-day-boundary.md
+++ b/_datasets/sanitation-collection-day-boundary.md
@@ -11,8 +11,7 @@ notes: "The data is used to determine the day of sanitation collection (rubbish 
   \ layer contain data signifying information relating it to the polygon layer. It\
   \ can tell you if both sides of the arc belong to one of the bounding polygons.\
   \  All the arcs, including those with no boundary info, have naming attributes for\
-  \ labeling the polygon borders. \r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ labeling the polygon borders. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/sanitation-convenience-centers.md
+++ b/_datasets/sanitation-convenience-centers.md
@@ -6,9 +6,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
-notes: "Sites where residents can drop off household trash and recycling.\r\n\r\n\
-  Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Sites where residents can drop off household trash and recycling."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/sanitation-districts.md
+++ b/_datasets/sanitation-districts.md
@@ -11,9 +11,7 @@ license: Other (City of Philadelphia)
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 notes: "Boundaries of city sanitation districts.  Collection areas are subdivisions\
-  \ of districts.  Districts are aggregated up to Sanitation Areas. \r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ of districts.  Districts are aggregated up to Sanitation Areas. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/schools.md
+++ b/_datasets/schools.md
@@ -17,8 +17,7 @@ notes: "Data includes points identifying public schools, charter schools, many p
   \ provides information on public, private, charter and archdiocesan schools. Please\
   \ keep in mind that this data, particularly with regards to enrollment, is constantly\
   \ changing or is not publicly available. If you have specific questions about a\
-  \ school, please contact that facility directly.__\r\n\r\nTrouble downloading or\
-  \ have questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ school, please contact that facility directly.__"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/shooting-victims.md
+++ b/_datasets/shooting-victims.md
@@ -6,9 +6,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: publicsafetygis@phila.gov
 maintainer_email: publicsafetygis@phila.gov
-notes: "City-wide shooting victims, including Police Officer-involved shootings\r\n\
-  \r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "City-wide shooting victims, including Police Officer-involved shootings"
 organization: City of Philadelphia
 resources:
 - description: Guided tour of the data, contextualized with other datasets

--- a/_datasets/snow-emergency-routes.md
+++ b/_datasets/snow-emergency-routes.md
@@ -19,8 +19,7 @@ notes: "From the Streets Department snow emergency route page\r\n\r\nWhen snow a
   \ file contains the IDs of all of the street segments that are classified as snow\
   \ emergency routes. The snow emergency routes shapefile/geojson is built by filtering\
   \ the street centerline layer to include only those rows where the seg_id is contained\
-  \ in this list.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ in this list."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/special-vending-districts.md
+++ b/_datasets/special-vending-districts.md
@@ -11,8 +11,7 @@ maintainer: 'ligisteam@phila.gov '
 maintainer_email: ligisteam@phila.gov
 notes: "Districts with special sidewalk vending rules pursuant to Sections 9-204 (Sidewalk\
   \ Vendors in Center City) and 9-206 (Sidewalk Vendors in Neighborhood Business Districts)\
-  \ of The Philadelphia Code.\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ of The Philadelphia Code."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/storefront-improvement-program-grants-disbursed.md
+++ b/_datasets/storefront-improvement-program-grants-disbursed.md
@@ -10,8 +10,7 @@ maintainer_email: ''
 notes: "This data set reflects the recipients, award amounts, and project sites for\
   \ grant money disbursed by the Philadelphia Commerce Department for the Storefront\
   \ Improvement Program whereby businesses are provided the funds to improve the exterior\
-  \ of their storefront.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ of their storefront."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/stormwater-management-practice-polygons.md
+++ b/_datasets/stormwater-management-practice-polygons.md
@@ -8,8 +8,7 @@ maintainer_email: raymond.pierdomenico@phila.gov
 notes: "This layer represents Green Stormwater Infrastructure Stormwater Management\
   \ Practice types. Integrating Green Stormwater Infrastructure (GSI) into a highly\
   \ developed area such as Philadelphia requires a decentralized and creative approach\
-  \ to planning and design.\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ to planning and design."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/stormwater-outfalls.md
+++ b/_datasets/stormwater-outfalls.md
@@ -8,9 +8,7 @@ maintainer_email: raymond.pierdomenico@phila.gov
 notes: "This point layer contains all the stormwater outfalls. The Purpose of this\
   \ data is to describe the asset both locationally and via its attributes which are\
   \ extensive for a GIS dataset and which are maintained. This data will serve as\
-  \ a platform for planning, analysis and research at PWD. \r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)\r\n"
+  \ a platform for planning, analysis and research at PWD.\r\n"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-centerlines-for-vision-zero-high-injury-network-2017.md
+++ b/_datasets/street-centerlines-for-vision-zero-high-injury-network-2017.md
@@ -9,9 +9,7 @@ maintainer_email: ''
 notes: "This dataset contains a modified version of street centerlines used for spatial\
   \ analysis to derive the High Injury Network (HIN). This version has been arrived\
   \ at, using steps described in the methodology for High Injury Network. See the\
-  \ Metadata link for an attached PDF describing the methodology.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ Metadata link for an attached PDF describing the methodology."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-centerlines.md
+++ b/_datasets/street-centerlines.md
@@ -16,9 +16,7 @@ notes: "Used citywide as base layer for many purposes/applications. The street c
   \ is available for reference purposes only and does not represent exact engineering\
   \ specifiactions. The Philadelphia Streets Department makes no guarantees as to\
   \ the accuracy of the layer. Associated tables can be found here: https://www.opendataphilly.org/dataset/street-place-names\
-  \  \r\nhttps://www.opendataphilly.org/dataset/street-name-alias-list \r\n\r\nTrouble\
-  \ downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \  \r\nhttps://www.opendataphilly.org/dataset/street-name-alias-list "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-lane-closure-emergency-utility-network.md
+++ b/_datasets/street-lane-closure-emergency-utility-network.md
@@ -5,8 +5,7 @@ license: Other (City of Philadelphia)
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 notes: "This layer shows the Philadelphia Gas Works (PGW) Emergency Utility Network\
-  \ (EUN) with Excavation points.  \r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ (EUN) with Excavation points.  "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-lane-closures.md
+++ b/_datasets/street-lane-closures.md
@@ -10,8 +10,7 @@ maintainer_email: max.steinbrenner@phila.gov
 notes: "Street lane closures for general public use. This is the master layer depicting\
   \ the Lane Closures due to permitted road work. This layer shows the type and purpose\
   \ of working being done, the effective dates of the permits issued, as well the\
-  \ status of the work.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ status of the work."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-legal-cards.md
+++ b/_datasets/street-legal-cards.md
@@ -12,8 +12,7 @@ maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
 notes: "Street Centerline Arcs with link to legal cards, which are a collection of\
   \ cards containing the official record of the legal description and drawings of\
-  \ city streets.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ city streets."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-name-alias-list.md
+++ b/_datasets/street-name-alias-list.md
@@ -7,8 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 notes: "Table to display street names which have aliased street names associated with\
-  \ them.\r\n\r\nTrouble downloading or have questions about this City dataset? Visit\
-  \ the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ them."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-nodes.md
+++ b/_datasets/street-nodes.md
@@ -9,8 +9,7 @@ license: Other (City of Philadelphia)
 maintainer: Dominick Cassise
 maintainer_email: dominick.cassise@phila.gov
 notes: "The street nodes layer was developed for use by agencies citywide including\
-  \ PWD, PCPC, Police, BRT, Health, etc. \r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ PWD, PCPC, Police, BRT, Health, etc. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/street-place-names.md
+++ b/_datasets/street-place-names.md
@@ -8,9 +8,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
-notes: "A listing of \"places\" and their corresponding addresses to be used for geocoding.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "A listing of \"places\" and their corresponding addresses to be used for geocoding."
 organization: City of Philadelphia
 resources:
 - description: 'Update Frequency: As Needed'

--- a/_datasets/street-poles.md
+++ b/_datasets/street-poles.md
@@ -11,9 +11,7 @@ maintainer_email: max.steinbrenner@phila.gov
 notes: "This layer was developed to aid the Street Lighting Division in planning,\
   \ referencing, and maintaining the active street poles within the City of Philadelphia.\
   \  Examples include: providing information regarding group replacement projects\
-  \ and any individual edits, using tables from layer for billing, and aiding cityworks.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ and any individual edits, using tables from layer for billing, and aiding cityworks."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/streets-code-violation-notices.md
+++ b/_datasets/streets-code-violation-notices.md
@@ -20,8 +20,7 @@ notes: "A code violation notice is issued from the Street's department when a pe
   \ datasets for all years.** \r\n\r\n**If you are comfortable with APIs, you can\
   \ also use the API links to access this data. You can learn more about how to use\
   \ the API at Carto\u2019s SQL API site and in the Carto guide in the section on\
-  \ making calls to the API.**\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ making calls to the API.**"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/tobacco-free-school-zones.md
+++ b/_datasets/tobacco-free-school-zones.md
@@ -10,9 +10,7 @@ notes: "Tobacco-free school zones included in the tobacco retailing regulations.
   \ part of the regulation prohibits new tobacco retailer permits within 500 feet\
   \ of any K-12 school property parcel. [For more information visit](http://www.phila.gov/health/Commissioner/regulationtobaccoretailing.html)\r\
   \n\r\nRelated datasets include the [Tobacco Retailers Permits](https://www.opendataphilly.org/dataset/tobacco-retailer-permits)\
-  \ and [Tobacco Youth Sales Violations](https://www.opendataphilly.org/dataset/tobacco-youth-sales-violations).\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ and [Tobacco Youth Sales Violations](https://www.opendataphilly.org/dataset/tobacco-youth-sales-violations)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/tobacco-retailer-permits.md
+++ b/_datasets/tobacco-retailer-permits.md
@@ -10,9 +10,7 @@ notes: "Retailers apply for a tobacco permit through an online application syste
   \ entering name, address, and other relevant business information. These data are\
   \ cleaned and stored in a database maintained by the Department of Public Health.\r\
   \n\r\nRelated datasets include the [Tobacco Youth Sales Violations](https://www.opendataphilly.org/dataset/tobacco-youth-sales-violations)\
-  \ and [Tobacco-Free School Zones](https://www.opendataphilly.org/dataset/tobacco-free-school-zones).\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ and [Tobacco-Free School Zones](https://www.opendataphilly.org/dataset/tobacco-free-school-zones)."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/topographic-contours.md
+++ b/_datasets/topographic-contours.md
@@ -14,8 +14,7 @@ notes: "This dataset is a contour data line segments representing the elevation 
   \ features covering the City of Philadelphia, PA, approximately 196 sq miles total.\
   \ Data is typically collected during the month of April. Data Development: Vector\
   \ (line) data representing the elevation of natural and artificial features in the\
-  \ project area.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ project area."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/track-streets.md
+++ b/_datasets/track-streets.md
@@ -7,8 +7,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: Mike Matela
 maintainer_email: michael.matela@phila.gov
-notes: "Street segments containing train tracks.\r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Street segments containing train tracks."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/traffic-districts.md
+++ b/_datasets/traffic-districts.md
@@ -8,8 +8,7 @@ maintainer_email: dominick.cassise@phila.gov
 notes: "This layer was developed to aid the Traffic Division in planning, organizing,\
   \ and maintaining traffic flow within the City of Philadelphia.  Examples include:\
   \  the maintenance and placing of stop signs and signals and monitoring street travel\
-  \ direction. \r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ direction. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/traffic-preventative-maintenance-districts.md
+++ b/_datasets/traffic-preventative-maintenance-districts.md
@@ -16,8 +16,7 @@ notes: "This layer was developed to aid the Traffic Division in planning, organi
   \ It can tell you if both sides of the arc belong to one of the bounding polygons.\
   \  All the arcs, including those with no boundary info, have naming attributes for\
   \ labeling the polygon borders.  Contact the Streets GIS unit for public consumption\
-  \ of the corresponding arc layer.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)\r\
+  \ of the corresponding arc layer.\r\
   \n"
 organization: City of Philadelphia
 resources:

--- a/_datasets/urban-agriculture-projects.md
+++ b/_datasets/urban-agriculture-projects.md
@@ -8,8 +8,7 @@ license: Other (City of Philadelphia)
 maintainer: Chris Park
 maintainer_email: chris.park@phila.gov
 notes: "Urban agriculture projects located within Philadelphia Parks and Recreation\
-  \ sites.\r\n\r\nTrouble downloading or have questions about this City dataset? Visit\
-  \ the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ sites."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/us-congressional-districts.md
+++ b/_datasets/us-congressional-districts.md
@@ -5,9 +5,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
-notes: "Please refer to PA's open data for the [United States Congressional Districts](https://data.pa.gov/Geospatial-Data/Pennsylvania-Congressional-District-Boundaries/3b9u-tn7c).\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Please refer to PA's open data for the [United States Congressional Districts](https://data.pa.gov/Geospatial-Data/Pennsylvania-Congressional-District-Boundaries/3b9u-tn7c)."
 organization: City of Philadelphia
 resources: []
 schema: default

--- a/_datasets/vacant-lot-cleanups.md
+++ b/_datasets/vacant-lot-cleanups.md
@@ -7,9 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "Dates and locations of when lots were cleaned (removing weeds, debris, etc.)\
-  \ through the City of Philadelphia's Community Life Improvement Program.\r\n\r\n\
-  Trouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ through the City of Philadelphia's Community Life Improvement Program."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/vacant-property-indicators-percentage-by-block.md
+++ b/_datasets/vacant-property-indicators-percentage-by-block.md
@@ -6,8 +6,7 @@ maintainer: tim.haynes@phila.gov
 maintainer_email: ''
 notes: "Block by block percentages across Philadelphia showing the percentages of\
   \ properties (buildings and lots) in each block considered likely to be vacant by\
-  \ the city's Vacant Property Indicators Model.\r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ the city's Vacant Property Indicators Model."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/vacant-property-indicators.md
+++ b/_datasets/vacant-property-indicators.md
@@ -6,8 +6,7 @@ maintainer: ''
 maintainer_email: tim.haynes@phila.gov
 notes: "The location of properties across Philadelphia that are likely to be a vacant\
   \ lot or vacant building based on an assessment of City of Philadelphia administrative\
-  \ datasets.\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ datasets."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/vehicle-pedestrian-investigations.md
+++ b/_datasets/vehicle-pedestrian-investigations.md
@@ -16,9 +16,7 @@ notes: "Police investigations of pedestrians and vehicles from the Philadelphia 
   ve split up the dataset by year. Please be sure to download data for all of the\
   \ years to see the full dataset. You can learn more about how to use the API at\
   \ [Carto\u2019s SQL API site](https://carto.com/developers/sql-api/) and in the\
-  \ [Carto guide in the section on making calls to the API](https://carto.com/developers/sql-api/guides/making-calls/).**\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ [Carto guide in the section on making calls to the API](https://carto.com/developers/sql-api/guides/making-calls/).**"
 organization: City of Philadelphia
 resources:
 - description: Guided tour of the data, contextualized with other datasets

--- a/_datasets/vehicular-crashes.md
+++ b/_datasets/vehicular-crashes.md
@@ -10,8 +10,7 @@ maintainer_email: ''
 notes: "This data set contains crash data for the years 2007-2020 from the Pennsylvania\
   \ Department of Transportation (Penn DOT). This is a subset of the [annual Crash\
   \ Data compiled](https://crashinfo.penndot.gov/PCIT/welcome.html) and released by\
-  \ Penn DOT for the entire state.\r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Penn DOT for the entire state."
 organization: City of Philadelphia
 resources:
 - description: This is a subset of the annual Crash Data compiled and released by

--- a/_datasets/vision-zero-high-injury-network.md
+++ b/_datasets/vision-zero-high-injury-network.md
@@ -10,9 +10,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "This data contains the High Injury Network. It is derived using spatial data\
-  \ analysis of crash data for years 2012-2016 from Pennsylvania Department of Transportation.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ analysis of crash data for years 2012-2016 from Pennsylvania Department of Transportation."
 organization: City of Philadelphia
 resources:
 - description: Visualization and methodology for the 2020 High Injury Network.

--- a/_datasets/voter-registration-counts.md
+++ b/_datasets/voter-registration-counts.md
@@ -8,8 +8,7 @@ maintainer: Seth Bluestein
 maintainer_email: seth.bluestein@phila.gov
 notes: "Information regarding individuals who are registered to vote (aka the Qualified\
   \ Voter Registry). This data is broken down into various reports for voter, election,\
-  \ and district information.\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ and district information."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/voter-turnout.md
+++ b/_datasets/voter-turnout.md
@@ -7,9 +7,7 @@ license: Other (City of Philadelphia)
 maintainer: Seth Bluestein
 maintainer_email: seth.bluestein@phila.gov
 notes: "Information regarding individuals who have voted and when. This data is broken\
-  \ down into various reports for voter, election, and district information.\r\n\r\
-  \nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ down into various reports for voter, election, and district information."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/water-department-grants-disbursed.md
+++ b/_datasets/water-department-grants-disbursed.md
@@ -20,8 +20,7 @@ notes: "Collection Process:  This data set reflects the recipients, award amount
   \ assistance to reduce their stormwater bill.\r\nIntended Audience:  It can also\
   \ be useful to community organizations interested in serving as stewards of green\
   \ infrastructure located in their area. And it can be useful to businesses impacted\
-  \ by PWD projects.\r\n\r\nTrouble downloading or have questions about this City\
-  \ dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ by PWD projects."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/water-inlets.md
+++ b/_datasets/water-inlets.md
@@ -9,8 +9,7 @@ license: Other (City of Philadelphia)
 maintainer: Larry Szarek
 maintainer_email: Larry.Szarek@phila.gov
 notes: "This point layer contains all the wastewater and stormwater inlets in Philadelphia\
-  \ with latitude and longitude coordinates. \r\n\r\nTrouble downloading or have questions\
-  \ about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ with latitude and longitude coordinates. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/watercourses-designated-for-protection.md
+++ b/_datasets/watercourses-designated-for-protection.md
@@ -14,8 +14,7 @@ notes: "Hydrographic features included in Philadelphia Hydrology Map. This map w
   \ Designated for Protection on September 13th, 2012. The geographic data depicts\
   \ watercourses within Philadelphia County as they appear on the map and will not\
   \ be edited or updated. For up-to-date hydrography see the Hydrolographic_Features_Poly\
-  \ layer under Hydrology.\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ layer under Hydrology."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/west-philadelphia-promise-zone.md
+++ b/_datasets/west-philadelphia-promise-zone.md
@@ -11,9 +11,7 @@ license: Other (City of Philadelphia)
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 notes: "Area designated by the U.S. Department of Housing and Urban Development deeming\
-  \ West Philadelphia as a Promise Zone. Click here to learn more about promise zones.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ West Philadelphia as a Promise Zone. Click here to learn more about promise zones."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/wire-waste-baskets-trash-bins.md
+++ b/_datasets/wire-waste-baskets-trash-bins.md
@@ -6,9 +6,7 @@ extras:
 license: Other (City of Philadelphia)
 maintainer: 'Max Steinbrenner '
 maintainer_email: max.steinbrenner@phila.gov
-notes: "Non Big Belly waste baskets maintained/collected by the City of Philadelphia.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)\r\n"
+notes: "Non Big Belly waste baskets maintained/collected by the City of Philadelphia.\r\n"
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/women-infants-children-wic-offices.md
+++ b/_datasets/women-infants-children-wic-offices.md
@@ -6,8 +6,7 @@ license: Other (City of Philadelphia)
 maintainer: ''
 maintainer_email: ''
 notes: "The Special Supplemental Nutrition Program for Women, Infants, and Children\
-  \ (WIC) .\r\n\r\nTrouble downloading or have questions about this City dataset?\
-  \ Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ (WIC) ."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/world-meeting-of-families-authorized-vehicle-route.md
+++ b/_datasets/world-meeting-of-families-authorized-vehicle-route.md
@@ -8,9 +8,7 @@ notes: "This layer highlights the authorized vehicle routes for the 2015 World M
   \ of Families. The routes will be held for public safety vehicles, emergency operations,\
   \ and other mission critical traffic. Regular traffic will not be permitted on the\
   \ routes. Check for updates frequently as information is subject to change. For\
-  \ a more detailed description of the event and operations: http://www.phila.gov/informationcenters/pope/.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ a more detailed description of the event and operations: http://www.phila.gov/informationcenters/pope/."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/world-meeting-of-families-secure-perimeter.md
+++ b/_datasets/world-meeting-of-families-secure-perimeter.md
@@ -4,9 +4,7 @@ extras: {}
 license: Other (City of Philadelphia)
 maintainer: OEM
 maintainer_email: oem@phila.gov
-notes: "Secure perimeter for the 2015 World Meeting of Families in Philadelphia, PA.\r\
-  \n\r\nTrouble downloading or have questions about this City dataset? Visit the [OpenDataPhilly\
-  \ Discussion Group](http://www.phila.gov/data/discuss/)"
+notes: "Secure perimeter for the 2015 World Meeting of Families in Philadelphia, PA."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/world-meeting-of-families-secure-vehicle-perimeter.md
+++ b/_datasets/world-meeting-of-families-secure-vehicle-perimeter.md
@@ -5,8 +5,7 @@ license: Other (City of Philadelphia)
 maintainer: OEM
 maintainer_email: oem@phila.gov
 notes: "Secure vehicle perimeter for the 2015 World Meeting of Families in Philadelphia,\
-  \ PA.\r\n\r\nTrouble downloading or have questions about this City dataset? Visit\
-  \ the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ PA."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/world-meeting-of-families-traffic-box.md
+++ b/_datasets/world-meeting-of-families-traffic-box.md
@@ -6,8 +6,7 @@ maintainer: OEM
 maintainer_email: oem@phila.gov
 notes: "Traffic box for the 2015 World Meeting of Families in Philadelphia, PA.  The\
   \ boundaries and bordering streets were released during a press conference at City\
-  \ Hall on August 5th, 2015.\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ Hall on August 5th, 2015."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/zip-codes.md
+++ b/_datasets/zip-codes.md
@@ -12,8 +12,7 @@ maintainer: Max Steinbrenner
 maintainer_email: max.steinbrenner@phila.gov
 notes: "The purpose of this dataset is to represent the Zip Code areas for the City\
   \ of Philadelphia.  The edges of Zip Codes are slightly modified for logical and\
-  \ cartographic purposes.\r\n\r\nTrouble downloading or have questions about this\
-  \ City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ cartographic purposes."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/zoning-base-districts.md
+++ b/_datasets/zoning-base-districts.md
@@ -15,9 +15,7 @@ maintainer_email: darshna.patel@phila.gov
 notes: "Polygon boundaries of Zoning Base Districts based on existing City zoning\
   \ districts with revised codes applied per enactment of the new Zoning Code of December\
   \ 2011, made effective August 22, 2012. District boundaries unchanged from previous\
-  \ zoning with the exception of certain CMX2 / CMX2.5 splits.\r\n\r\nTrouble downloading\
-  \ or have questions about this City dataset? Visit the [OpenDataPhilly Discussion\
-  \ Group](http://www.phila.gov/data/discuss/)"
+  \ zoning with the exception of certain CMX2 / CMX2.5 splits."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/zoning-overlays.md
+++ b/_datasets/zoning-overlays.md
@@ -6,8 +6,7 @@ license: Other (City of Philadelphia)
 maintainer: Darshna Patel
 maintainer_email: darshna.patel@phila.gov
 notes: "Boundaries of the City of Philadelphia Zoning Overlay Districts enacted December\
-  \ 15, 2011 and made effective August 22, 2012.\r\n\r\nTrouble downloading or have\
-  \ questions about this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ 15, 2011 and made effective August 22, 2012."
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_datasets/zoning-steep-slope-protected-area.md
+++ b/_datasets/zoning-steep-slope-protected-area.md
@@ -7,8 +7,7 @@ maintainer: 'Darshna Patel '
 maintainer_email: darshna.patel@phila.gov
 notes: "Boundaries of the City's Steep Slope Overlay district enacted under Section\
   \ 14-704(2) of the Zoning Code of December 2011 and made effective August 22, 2012.\
-  \ See code for further details. \r\n\r\nTrouble downloading or have questions about\
-  \ this City dataset? Visit the [OpenDataPhilly Discussion Group](http://www.phila.gov/data/discuss/)"
+  \ See code for further details. "
 organization: City of Philadelphia
 resources:
 - description: ''

--- a/_includes/datasets.html
+++ b/_includes/datasets.html
@@ -1,6 +1,6 @@
 {% for dataset in include.datasets %}
 <dataset>
   <h3><a href="{{ site.baseurl }}{{ dataset.url }}">{{ dataset.title }}</a></h3>
-  {{ dataset.notes | truncate: 300, '...' }}
+  {{ dataset.notes | markdownify | truncate: 300, '...' }}
 </dataset>
 {% endfor %}

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -28,7 +28,7 @@ layout: default
           {% for dataset in datasets %}
            <dataset>
              <h3><a href="{{ site.baseurl }}{{ dataset.url }}">{{ dataset.title }}</a></h3>
-             {{ dataset.notes }}
+             {{ dataset.notes | markdownify }}
              
            </dataset>
           {% endfor %}

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -29,7 +29,7 @@ layout: default
                           </h3>
                             </div>
                             <div class="card-body">
-                          {{ organization.description }}
+                          {{ organization.description | markdownify }}
                         </div>
                         <div class="view-code-link">
                           <a href="{% github_edit_link %}"  target="_blank"><i class="fa fa-code"></i> Open in GitHub</a>

--- a/_layouts/organization.html
+++ b/_layouts/organization.html
@@ -28,7 +28,7 @@ layout: default
            {% for dataset in datasets %}
             <dataset>
               <h3><a href="{{ site.baseurl }}{{ dataset.url }}">{{ dataset.title }}</a></h3>
-              {{ dataset.notes }}
+              {{ dataset.notes | markdownify }}
             </dataset>
            {% endfor %}
           </div>

--- a/datasets.html
+++ b/datasets.html
@@ -40,7 +40,7 @@ permalink: /datasets/
       {% for dataset in site.datasets %}
       <dataset>
         <h3><a href="{{ site.baseurl }}{{ dataset.url }}">{{ dataset.title }}</a></h3>
-        {{ dataset.notes }}
+        {{ dataset.notes | markdownify }}
       </dataset>
       {% endfor %}
     </div>

--- a/datasets.json
+++ b/datasets.json
@@ -4,7 +4,7 @@
   {
     "title": {{ dataset.title | jsonify }},
     "organization": {{ dataset.organization | jsonify }}{% if dataset.notes != "" %},
-    "notes": {{ dataset.notes | jsonify }}{% endif %}{% if dataset.category != "" %},
+    "notes": {{ dataset.notes | markdownify | jsonify }}{% endif %}{% if dataset.category != "" %},
     "category": {{ dataset.category | jsonify }}{% endif %},
     "url": "{{ site.baseurl }}{{ dataset.url }}"
   }{% unless forloop.last %},{% endunless %}{% endfor %}

--- a/organizations.html
+++ b/organizations.html
@@ -21,7 +21,7 @@ permalink: /organizations/
         {% endif %}
         <div class="ms-3">
           <h4 style="text-align: start;">{{ organization.title }}</h4>
-          <p style="text-align: justify;">{{ organization.description }}</p>
+          <p style="text-align: justify;">{{ organization.description | markdownify }}</p>
         </div>
       </div>
     </a>


### PR DESCRIPTION
Dropped ODP Google Group from each Phila dataset.

Markdownified the description/notes output.  This still could use some work, but I think it works well enough.

Resolves: #28