### PR TITLE
Drop Netlify edit, tweak other changes around v2 name change

### DIFF
--- a/.github/ISSUE_TEMPLATE/rebase-to-upstream.md
+++ b/.github/ISSUE_TEMPLATE/rebase-to-upstream.md
@@ -12,10 +12,10 @@ assignees: ''
 - [ ] git remote add upstream https://github.com/timwis/jkan.git
 
 ### 
-- [ ] git fetch upstream v2:upstream
-- [ ] git checkout -b v2_rebase_unique_branch_name
+- [ ] git fetch upstream main:upstream
+- [ ] git checkout -b main_rebase_unique_branch_name
 - [ ] git rebase upstream - may have some conflicts - go through and resolve them
-- [ ] git rebase v2 - - may have some conflicts - go through and resolve them
+- [ ] git rebase main - - may have some conflicts - go through and resolve them
 - [ ] git push -u origin HEAD
 - [ ] Go the PR on GitHub, review changes, ask for another review.
 - [ ] This process should allow you to do a rebase to commit the changes.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,7 +43,7 @@
   var settings = {
     BASE_URL: {{ site.baseurl | jsonify }} || "",
     PAGE_URL: {{ page.url | jsonify }},
-    REPO_BRANCH: {% if site.github.is_user_page %}"master"{% else %}"gh-pages"{% endif %},
+    REPO_BRANCH: {% if site.github.is_user_page %}"main"{% else %}"main"{% endif %},
     REPO_OWNER: {{ site.github.owner_name | jsonify }},
     REPO_NAME: {{ site.github.project_title | jsonify }}
   }

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -17,7 +17,6 @@ layout: default
     {% endif %}
       <h1>
         {{ page.name }}
-        <a href="{{ "/editor" | relative_url }}/#/collections/categories/entries/{{ page.slug }}" class="float-end btn btn-outline-secondary admin-only">Edit</a>
       </h1>
       <p>{{ page.description }}</p>
       <div data-component="datasets-list" data-category="{{ page.name | slugify }}">
@@ -34,9 +33,6 @@ layout: default
           {% endfor %}
          </div>
       </div>
-    </div>
-    <div class="view-code-link">
-      <a href="{% github_edit_link %}"  target="_blank"><i class="fa fa-code"></i> Open in GitHub</a>
     </div>
   </div>
 </div>

--- a/_layouts/dataset.html
+++ b/_layouts/dataset.html
@@ -31,9 +31,6 @@ layout: default
                             <div class="card-body">
                           {{ organization.description | markdownify }}
                         </div>
-                        <div class="view-code-link">
-                          <a href="{% github_edit_link %}"  target="_blank"><i class="fa fa-code"></i> Open in GitHub</a>
-                        </div>
                       </div>
           </div>
       <div class="col">
@@ -42,7 +39,6 @@ layout: default
       {% endif %}
         <h1>
           <span property="dct:title">{{ page.title }}</span>
-          <a href="{{ "/editor" | relative_url }}/#/collections/datasets/entries/{{ page.slug }}" class="pull-right btn btn-outline-secondary" data-hook="edit-dataset-btn">Edit</a>
         </h1>
         <p property="dct:description" style="text-align: justify; overflow-wrap: break-word;">{{ page.notes }}</p>
 
@@ -105,6 +101,7 @@ layout: default
           {% endfor %}
 
         </table>
+        <a href="{{site.github.repository_url}}/tree/main/{{page.path}}"  target="_blank"><i class="fa fa-code"></i> Open in GitHub</a>
       </div>
     </div>
   </div>

--- a/_layouts/organization.html
+++ b/_layouts/organization.html
@@ -17,7 +17,6 @@ layout: default
       {% endif %}
         <h1>
           {{ page.title }}
-          <a href="{{ "/editor" | relative_url }}/#/collections/organizations/entries/{{ page.slug }}" class="float-end btn btn-outline-secondary">Edit</a>
         </h1>
         <p>{{ page.description }}</p>
         <div data-component="datasets-list" data-organization="{{ page.title | slugify }}">
@@ -33,9 +32,6 @@ layout: default
            {% endfor %}
           </div>
         </div>
-      </div>
-      <div class="view-code-link">
-        <a href="{% github_edit_link %}"  target="_blank"><i class="fa fa-code"></i> Open in GitHub</a>
       </div>
     </div>
 </div>


### PR DESCRIPTION
Works around https://github.com/jekyll/github-metadata/issues/249

Only kept Edit on Github link for datasets as the others will not be as common.

Moved Open in Github link so it's clearly more related to the dataset instead of the org sidebar.

Resolves: #31, #37