### PR TITLE
Fix weird organization cards (#47)

### DIFF
--- a/_organizations/city-of-philadelphia.md
+++ b/_organizations/city-of-philadelphia.md
@@ -14,7 +14,7 @@ description: "**TERMS OF USE**: Browsing City data on this site constitutes acce
   **OVERVIEW**: Explore open data from the City of Philadelphia and learn more about\
   \ the City's effort to make more available. Open data is becoming a key part of\
   \ the way governments conduct business and reach constituents. Learn what's next\
-  \ for the City's [Open Data Program](https://beta.phila.gov/programs/open-data-program/)."
+  \ for the City's Open Data Program (https://beta.phila.gov/programs/open-data-program/)."
 logo: img/organizations/2019-05-28-133551.204260city-of-philadelphia-bell.png
 schema: default
 tags:

--- a/_organizations/walk-score.md
+++ b/_organizations/walk-score.md
@@ -1,8 +1,8 @@
 ---
 description: "Walk Score's mission is to promote walkable neighborhoods. Walkable\
   \ neighborhoods are one of the simplest and best solutions for the environment,\
-  \ our health, and our economy. https://www.walkscore.com/\r\n\r\n[How Walk Score\
-  \ Works](https://www.redfin.com/how-walk-score-works)"
+  \ our health, and our economy. https://www.walkscore.com/\r\n\r\n \
+  \ https://www.redfin.com/how-walk-score-works"
 logo: https://pbs.twimg.com/profile_images/520307458678329344/ZS8cOv2V_400x400.png
 schema: default
 tags: []


### PR DESCRIPTION
Jekyll is getting confused while turning md links into html anchors, at least in the organization description, which is itself inside an anchor. Currently we can't have links render in organization descriptions.
before (each of these card like segments has its own hover effect :vomiting_face: )
![odp-47](https://user-images.githubusercontent.com/36001800/233405684-96ed851c-a9ad-4493-9d7d-a20298e723fd.png)
after (not great but not nearly as confusing)
![odp-47-after](https://user-images.githubusercontent.com/36001800/233405683-8e57c798-40ad-4ff2-a993-4dd0e79b3d76.png)

Resolves #47 

