### PR TITLE
Create a 404 page and redirect CKAN links (#50)

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,28 @@
+---
+# example 404.md
+
+layout: default
+permalink: /404.html
+---
+
+# 404
+
+There is not a page at this URL.
+
+If your URL contains `/dataset` instead of `/datasets`, `/organization` instead of `/organizations`, or `/group` instead of `/categories`, you may have followed a link from an older version of Open Data Philly. In this case, we will try to redirect you, but this will not work if you have disabled JavaScript.
+
+Try searching for your dataset on the [datasets](/datasets) page.
+
+<script>
+    if (window.location.pathname.startsWith("/dataset/")) {
+        window.location.href = "/datasets" + window.location.pathname.slice(8);
+    } else if (window.location.pathname.startsWith("/organization/")) {
+        window.location.href = "/organizations" + window.location.pathname.slice(13);
+    } else if (window.location.pathname.startsWith("/group/")) {
+        if (window.location.pathname.endsWith("-group")) {
+            window.location.href = "/categories" + window.location.pathname.slice(6, -6)
+        } else {
+            window.location.href = "/categories" + window.location.pathname.slice(6);
+        }
+    }
+</script>


### PR DESCRIPTION
Adds a 404 page.
Adds a JS-based redirect to the 404 page, e.g.:
`/dataset` -> `/datasets`
`/organization` -> `/organizations`
`/group` -> `/categories`


http://localhost:4000/dataset
![odp-404](https://user-images.githubusercontent.com/36001800/234112321-c1b2173e-17a5-49ad-b9bb-3ff075964a71.png)

Resolves #50 
