### PR TITLE
Fix vending-prohibition-exceptions

### DIFF
--- a/_datasets/vending-prohibition-exceptions.md
+++ b/_datasets/vending-prohibition-exceptions.md
@@ -37,4 +37,5 @@ resources:
   url: https://metadata.phila.gov/#home/datasetdetails/63ea7b833a6d260011344674/representationdetails/63ea7b833a6d260011344683/
 schema: philadelphia
 source: ''
-tags:
+title: Vending Prohibition Exceptions
+---


### PR DESCRIPTION
The dataset wasn't showing up before because it didn't have a title. I also lowercased the filename for consistency.

We may want to make a reviewer checklist and drop it into a PR template so we can catch things like this before they get merged. One step would be pasting the yaml into a [tool](https://www.yamllint.com/) that can validate it, and another would be checking for the required properties.