### PR TITLE
Add a CODEOWNERS file to get auto review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owners
+* @lydiascarf @BryanQuigley
+
+/_organizations/city-of-philadelphia.md @lydiascarf @BryanQuigley @jrmidkiff


### PR DESCRIPTION
Adds Bryan and I as CODEOWNERS, to be automatically requested on new PRs. See [here](https://github.com/azavea/opendataphilly-jkan/compare/codeowners-init...codeowners-init-test?expand=1) for what it'll look like if you open a PR against main after this gets merged. Particularly, you should look at the "Reviewers" section and note who will be requested. I also pushed a test branch [here](https://github.com/azavea/opendataphilly-jkan/compare/codeowners-init...codeowners-init-test-org?expand=1) where you can see that @jrmidkiff will be additionally auto requested for changes to the city org.

Open Questions:
- @BryanQuigley I'd be curious to know if, when you follow the above link, it says that I'll be requested and you won't. I see it as you being requested and me not being requested. I assume that's how it works, but I just want to double check.
- We don't have a team so we may not be able to do the round robin thing we set up when we were at Azavea. See docs [here](https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team) for that process.
- Finally, I'm not sure the best way to assign someone from the city as a CODEOWNER on their datasets since those files would have to be matched by filename patterns. Could we put the city datasets in a subdir? I'd rather not enforce a naming scheme, but I think it would be smart to prove out a process for this kind of thing if we are going to pick up more contributors